### PR TITLE
feat: add theme toggle and fix LaTeX exponents

### DIFF
--- a/public/visor/index.html
+++ b/public/visor/index.html
@@ -175,6 +175,8 @@
       max-width: 350px; min-width: 200px; border-radius: 8px; color: #333; font-size: 14px; line-height: 1.4;
     }
     .note-popup .math-field { display: inline-block; margin: 2px; background: #f8f9fa; padding: 2px 4px; border-radius: 3px; }
+    .note-popup svg { max-width: 100%; height: auto; }
+    .note-popup .MathJax_SVG { font-size: 1em !important; }
     .note-popup .note-counter { text-align: right; margin-top: 8px; font-size: 12px; color: #555; }
 
     .note-textarea {


### PR DESCRIPTION
## Summary
- add toggle to switch between light and dark modes
- ensure MathJax keeps exponents by preserving delimiters and only typesetting on display
- convert stored `$...$` sequences back into editable MathQuill fields so LaTeX exponents persist across re-edits
- invert PDF canvas colors in dark mode
- prevent arrow keys in note popups from changing pages

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (prompts for ESLint configuration)


------
https://chatgpt.com/codex/tasks/task_e_6898dff3fbd48330bbd82ae06612e134