### PR TITLE
feat: add theme toggle and fix LaTeX exponents

### DIFF
--- a/public/visor/index.html
+++ b/public/visor/index.html
@@ -23,6 +23,10 @@
       color: #fff;
       overflow: hidden;
     }
+    body.light-mode {
+      background: #fff;
+      color: #202124;
+    }
 
     #app-header {
       padding: 8px 16px;
@@ -35,8 +39,14 @@
       position: relative;
       z-index: 100;
     }
+    body.light-mode #app-header {
+      background: #f1f3f4;
+      border-bottom: 1px solid #dadce0;
+      color: #202124;
+    }
     .header-left { display: flex; align-items: center; gap: 16px; }
     .header-center { flex: 1; text-align: center; font-size: 14px; color: #e8eaed; }
+    body.light-mode .header-center { color: #202124; }
     .header-right { display: flex; align-items: center; gap: 8px; }
 
     .control-btn {
@@ -46,6 +56,8 @@
     }
     .control-btn:hover { background: rgba(255,255,255,0.1); }
     .control-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+    body.light-mode .control-btn { color: #202124; }
+    body.light-mode .control-btn:hover { background: rgba(0,0,0,0.1); }
 
     #zoom-display { min-width: 60px; text-align: center; font-size: 13px; }
 
@@ -55,6 +67,7 @@
       background: #525659; z-index: 100;
     }
     #drop-zone.hidden { display: none; }
+    body.light-mode #drop-zone { background: #fff; }
 
     .upload-area {
       border: 2px dashed #8ab4f8; border-radius: 8px; padding: 48px; text-align: center;
@@ -72,6 +85,7 @@
       overflow-y: auto; overflow-x: auto; display: flex; flex-direction: column;
       align-items: center; gap: 8px; padding: 16px 0; background: #525659;
     }
+    body.light-mode #pdf-container { background: #fff; }
 
     /* Desactivar scroll mientras carga o se guarda */
     #pdf-container.no-scroll {
@@ -81,6 +95,12 @@
     .page-wrapper {
       position: relative; background: #fff; box-shadow: 0 2px 10px rgba(0,0,0,0.3);
       margin-bottom: 8px;
+    }
+    body:not(.light-mode) .page-wrapper {
+      background: #1e1e1e;
+    }
+    body:not(.light-mode) .page-wrapper canvas {
+      filter: invert(1) hue-rotate(180deg);
     }
     .anno-layer { position: absolute; top: 0; left: 0; pointer-events: none; }
     .page-number {
@@ -118,6 +138,7 @@
       opacity: 0;
       pointer-events: none;
     }
+    body.light-mode .loading-overlay { background: #fff; }
     .loading-box {
       display: flex;
       align-items: center;
@@ -154,11 +175,19 @@
       max-width: 350px; min-width: 200px; border-radius: 8px; color: #333; font-size: 14px; line-height: 1.4;
     }
     .note-popup .math-field { display: inline-block; margin: 2px; background: #f8f9fa; padding: 2px 4px; border-radius: 3px; }
+    .note-popup .note-counter { text-align: right; margin-top: 8px; font-size: 12px; color: #555; }
+    .note-popup mjx-container {
+      font-size: 1em !important;
+    }
+    .note-popup mjx-container[display="true"] {
+      display: inline-block !important;
+      margin: 0 !important;
+    }
 
     .note-textarea {
       position: fixed; z-index: 1500; border: 2px solid #8ab4f8; border-radius: 8px; padding: 12px; background: white;
       box-shadow: 0 4px 20px rgba(0,0,0,0.3); font-family: inherit; resize: both; min-width: 250px; min-height: 120px;
-      color: #333; font-size: 14px; line-height: 1.4; outline: none;
+      color: #333; font-size: 14px; line-height: 1.4; outline: none; overflow: auto;
     }
     .note-textarea:focus { border-color: #4285f4; }
     .mq-editable-field, .mq-editable-field .mq-root-block {
@@ -271,6 +300,7 @@
         <button class="control-btn" id="folder-btn" title="Configurar carpeta">⚙️</button>
       </div>
 
+      <button class="control-btn" id="theme-toggle" title="Cambiar tema">🌙</button>
       <button class="control-btn" id="info-btn" title="Ayuda">ℹ️</button>
     </div>
   </header>
@@ -391,6 +421,7 @@
       const fullscreenBtn = document.getElementById('fullscreen-btn');
       const backBtn = document.getElementById('back-btn');
       let navIndicator = document.getElementById('nav-indicator');
+      const themeToggleBtn = document.getElementById('theme-toggle');
 
       // Overlay de carga
       let loadingOverlay = document.getElementById('loading-overlay');
@@ -425,6 +456,11 @@
       let activeIcon = null;
       let creatingNote = false;
       const MQ = MathQuill.getInterface(2);
+
+      themeToggleBtn.addEventListener('click', () => {
+        document.body.classList.toggle('light-mode');
+        themeToggleBtn.textContent = document.body.classList.contains('light-mode') ? '🌞' : '🌙';
+      });
 
       // Persistencia de notas
       let directoryHandle = null;
@@ -1161,12 +1197,16 @@
       // ========================================
       // SISTEMA DE NOTAS (existente)
       // ========================================
-      function renderContentInElement(element, htmlContent) {
+      function renderContentInElement(element, htmlContent, makeEditable = false) {
         element.innerHTML = '';
         const tempDiv = document.createElement('div');
         tempDiv.innerHTML = htmlContent;
         Array.from(tempDiv.childNodes).forEach(node => element.appendChild(node.cloneNode(true)));
-        initMathFields(element);
+        if (makeEditable) {
+          initMathFields(element);
+        } else if (window.MathJax && window.MathJax.typesetPromise) {
+          MathJax.typesetPromise([element]);
+        }
       }
       function createTextarea(x, y, icon, targetLayer) {
         const textarea = document.createElement('div');
@@ -1176,7 +1216,8 @@
         textarea.style.left = (pageRect.left + x) + 'px';
         textarea.style.top = (pageRect.top + y) + 'px';
         if (icon) {
-          renderContentInElement(textarea, processNoteContent(icon.dataset.content));
+          const contentForEdit = icon.dataset.content.replace(/<span class="note-sep"><\/span>/g, '\\n');
+          renderContentInElement(textarea, processNoteContent(contentForEdit, true), true);
         } else {
           textarea.innerHTML = '<p></p>';
         }
@@ -1207,15 +1248,15 @@
 
         textarea.addEventListener('blur', (ev) => {
           if (ev.relatedTarget && ev.relatedTarget.closest('.note-textarea')) return;
-          const tempDiv = document.createElement('div');
-          Array.from(textarea.childNodes).forEach(node => tempDiv.appendChild(node.cloneNode(true)));
-          tempDiv.querySelectorAll('span.math-field').forEach(span => {
-            if (span._mqInstance) {
-              const latex = span._mqInstance.latex();
-              span.textContent = `$${latex}$`;
-            }
+          const tempDiv = textarea.cloneNode(true);
+          const origSpans = textarea.querySelectorAll('span.math-field');
+          const cloneSpans = tempDiv.querySelectorAll('span.math-field');
+          origSpans.forEach((orig, idx) => {
+            const latex = orig._mqInstance ? orig._mqInstance.latex() : '';
+            cloneSpans[idx].textContent = `$${latex}$`;
           });
-          const content = tempDiv.innerHTML.trim();
+          const rawContent = tempDiv.innerHTML.trim();
+          const content = rawContent.replace(/\\n/g, '<span class="note-sep"></span>');
           document.body.removeChild(textarea);
           if (content && content !== '<p></p>') {
             if (icon) {
@@ -1230,15 +1271,41 @@
           }
         });
       }
-      function processNoteContent(content) {
+      function processNoteContent(content, stripDelimiters = false) {
         const tempDiv = document.createElement('div');
         tempDiv.innerHTML = content;
+
+        if (stripDelimiters) {
+          // Convert $...$ into editable math-field spans
+          const walker = document.createTreeWalker(tempDiv, NodeFilter.SHOW_TEXT);
+          const textNodes = [];
+          while (walker.nextNode()) textNodes.push(walker.currentNode);
+          textNodes.forEach(node => {
+            const parts = node.textContent.split(/\$([^$]+)\$/g);
+            if (parts.length > 1) {
+              const frag = document.createDocumentFragment();
+              for (let i = 0; i < parts.length; i++) {
+                if (i % 2 === 0) {
+                  if (parts[i]) frag.appendChild(document.createTextNode(parts[i]));
+                } else {
+                  const span = document.createElement('span');
+                  span.className = 'math-field';
+                  span.textContent = parts[i];
+                  frag.appendChild(span);
+                }
+              }
+              node.parentNode.replaceChild(frag, node);
+            }
+          });
+        }
+
         tempDiv.querySelectorAll('span.math-field').forEach(span => {
           const textContent = span.textContent || '';
-          if (textContent.startsWith('$') && textContent.endsWith('$')) {
+          if (stripDelimiters && textContent.startsWith('$') && textContent.endsWith('$')) {
             span.textContent = textContent.substring(1, textContent.length - 1);
           }
         });
+
         return tempDiv.innerHTML;
       }
       function enhanceMathField(span) {
@@ -1281,12 +1348,39 @@
         hidePopup();
         const popup = document.createElement('div');
         popup.className = 'note-popup';
-        renderContentInElement(popup, processNoteContent(icon.dataset.content));
+        popup.tabIndex = 0;
+        document.body.appendChild(popup);
+        const parts = icon.dataset.content.split('<span class="note-sep"></span>');
+        let partIndex = 0;
+        function renderPart() {
+          renderContentInElement(popup, processNoteContent(parts[partIndex]));
+          if (parts.length > 1) {
+            const counter = document.createElement('div');
+            counter.className = 'note-counter';
+            counter.textContent = `${partIndex + 1}/${parts.length}`;
+            popup.appendChild(counter);
+          }
+        }
+        renderPart();
         const iconRect = icon.getBoundingClientRect();
         popup.style.left = (iconRect.left + window.scrollX) + 'px';
         popup.style.top = (iconRect.bottom + window.scrollY + 5) + 'px';
-        document.body.appendChild(popup);
         activePopup = popup; activeIcon = icon;
+        popup.focus();
+        popup.addEventListener('keydown', (e) => {
+          if (e.key === 'ArrowRight' || e.key === 'ArrowLeft') {
+            if (parts.length > 1) {
+              if (e.key === 'ArrowRight') {
+                partIndex = (partIndex + 1) % parts.length;
+              } else {
+                partIndex = (partIndex - 1 + parts.length) % parts.length;
+              }
+              renderPart();
+            }
+            e.preventDefault();
+            e.stopPropagation();
+          }
+        });
         popup.addEventListener('mouseleave', () => {
           setTimeout(() => {
             if (!popup.matches(':hover') && !icon.matches(':hover')) hidePopup();


### PR DESCRIPTION
## Summary
- add toggle to switch between light and dark modes
- ensure MathJax keeps exponents by preserving delimiters and only typesetting on display
- convert stored `$...$` sequences back into editable MathQuill fields so LaTeX exponents persist across re-edits
- invert PDF canvas colors in dark mode
- prevent arrow keys in note popups from changing pages
- normalize MathJax output within note popups to keep fonts at regular size
- typeset note popups only after they are in the DOM so math renders at the correct scale

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: prompts "How would you like to configure ESLint?")


------
https://chatgpt.com/codex/tasks/task_e_6898dff3fbd48330bbd82ae06612e134