### PR TITLE
feat: add pdf generator and prompts

### DIFF
--- a/public/visor/index.html
+++ b/public/visor/index.html
@@ -282,6 +282,8 @@
       margin-top: 12px;
     }
     .prompt-actions .category-btn { width: 100%; max-width: 300px; }
+    .prompt-item { display: flex; align-items: center; gap: 8px; justify-content: center; width: 100%; }
+    .edit-prompt { background: none; border: none; cursor: pointer; font-size: 18px; }
     .pdf-draggable {
       margin-top: 16px;
       padding: 10px 14px;
@@ -534,12 +536,38 @@
       let theoryHandle = null;
       let practiceHandle = null;
 
+      const PROMPT_FILE = 'prompts.json';
       const USER_PROMPTS = {
-        resumen: localStorage.getItem('prompt_resumen') || 'Resumen del contenido',
-        vf: localStorage.getItem('prompt_vf') || 'Genera preguntas de verdadero/falso del contenido',
-        reciprocos: localStorage.getItem('prompt_reciprocos') || 'Enumera recíprocos del contenido',
-        practica: localStorage.getItem('prompt_practica') || 'Extraer {"tema","enunciado","ejercicio"}'
+        resumen: '',
+        vf: '',
+        reciprocos: '',
+        practica: ''
       };
+
+      async function loadPromptConfig() {
+        if (!directoryHandle || !supportsFileSystemAccess()) return;
+        try {
+          const fileHandle = await directoryHandle.getFileHandle(PROMPT_FILE);
+          const file = await fileHandle.getFile();
+          const data = JSON.parse(await file.text());
+          Object.assign(USER_PROMPTS, data);
+        } catch {
+          await savePromptConfig();
+        }
+      }
+
+      async function savePromptConfig() {
+        if (!directoryHandle || !supportsFileSystemAccess()) return;
+        try {
+          const fileHandle = await directoryHandle.getFileHandle(PROMPT_FILE, { create: true });
+          const writable = await fileHandle.createWritable();
+          await writable.write(JSON.stringify(USER_PROMPTS, null, 2));
+          await writable.close();
+        } catch (e) {
+          console.error('Error guardando prompts:', e);
+          showToast('No se pudo guardar prompts', 'error');
+        }
+      }
 
       // ========================================
       // UTILIDADES UI
@@ -1542,6 +1570,7 @@
               if (permissionStatus === 'granted') {
                 directoryHandle = handle;
                 updateFileStatus('saved', 'Acceso concedido');
+                await loadPromptConfig();
               } else {
                 updateFileStatus('no-access', 'Acceso denegado');
               }
@@ -1568,6 +1597,7 @@
             const store = transaction.objectStore('settings');
             await store.put({ id: 'notesFolder', handle: directoryHandle });
             updateFileStatus('saved', 'Acceso concedido');
+            await loadPromptConfig();
             showToast('Carpeta configurada correctamente', 'success');
             hidePermissionModal();
             if (currentPdfName) setTimeout(loadNotesFromFile, 500);
@@ -1894,6 +1924,8 @@
             pdfModalBody.innerHTML = '<p>No se generó PDF.</p>';
             return;
           }
+          await loadPromptConfig();
+          triggerDownload(pdfData.blob, pdfData.file.name);
           renderPromptOptions(cat, pdfData);
         } catch (e) {
           console.error('Error generando PDF:', e);
@@ -1902,17 +1934,30 @@
         }
       }
 
+      function triggerDownload(blob, filename) {
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = filename;
+        document.body.appendChild(a);
+        a.click();
+        setTimeout(() => {
+          URL.revokeObjectURL(url);
+          a.remove();
+        }, 1000);
+      }
+
       function renderPromptOptions(cat, pdfData) {
         let html = '';
         if (cat === 'teo') {
           html += `<div class="prompt-actions">
-            <button class="category-btn teo" data-prompt="resumen">Resumen</button>
-            <button class="category-btn teo" data-prompt="vf">Verdaderos o falsos</button>
-            <button class="category-btn teo" data-prompt="reciprocos">Recíprocos</button>
+            <div class="prompt-item"><button class="category-btn teo" data-prompt="resumen">Resumen</button><button class="edit-prompt" data-edit="resumen">⚙️</button></div>
+            <div class="prompt-item"><button class="category-btn teo" data-prompt="vf">Verdaderos o falsos</button><button class="edit-prompt" data-edit="vf">⚙️</button></div>
+            <div class="prompt-item"><button class="category-btn teo" data-prompt="reciprocos">Recíprocos</button><button class="edit-prompt" data-edit="reciprocos">⚙️</button></div>
           </div>`;
         } else {
           html += `<div class="prompt-actions">
-            <button class="category-btn prac" data-prompt="practica">Extraer {&quot;tema&quot;,&quot;enunciado&quot;,&quot;ejercicio&quot;}</button>
+            <div class="prompt-item"><button class="category-btn prac" data-prompt="practica">Extraer {&quot;tema&quot;,&quot;enunciado&quot;,&quot;ejercicio&quot;}</button><button class="edit-prompt" data-edit="practica">⚙️</button></div>
           </div>`;
         }
         html += '<div id="pdf-drop-area"></div>';
@@ -1921,12 +1966,31 @@
         pdfModalBody.querySelectorAll('[data-prompt]').forEach(btn => {
           btn.addEventListener('click', async () => {
             const key = btn.getAttribute('data-prompt');
-            const text = USER_PROMPTS[key] || '';
+            let text = USER_PROMPTS[key] || '';
+            if (!text) {
+              const input = window.prompt('Ingresa prompt');
+              if (!input) { showToast('Prompt vacío', 'info'); return; }
+              USER_PROMPTS[key] = input;
+              await savePromptConfig();
+              text = input;
+            }
             try {
               await navigator.clipboard.writeText(text);
               showToast('Prompt copiado', 'success');
             } catch {
               showToast('No se pudo copiar', 'error');
+            }
+          });
+        });
+        pdfModalBody.querySelectorAll('.edit-prompt').forEach(icon => {
+          icon.addEventListener('click', async (ev) => {
+            ev.stopPropagation();
+            const key = icon.getAttribute('data-edit');
+            const current = USER_PROMPTS[key] || '';
+            const input = window.prompt('Editar prompt', current);
+            if (input !== null) {
+              USER_PROMPTS[key] = input;
+              await savePromptConfig();
             }
           });
         });

--- a/public/visor/index.html
+++ b/public/visor/index.html
@@ -272,6 +272,27 @@
     .category-btn.teo { background: #0ea5a3; }
     .category-btn.prac { background: #16a34a; }
     .category-tip { color: #666; font-size: 13px; margin-top: 8px; text-align: center; }
+
+    /* Modal de prompts y PDF generado */
+    .prompt-actions {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+      align-items: center;
+      margin-top: 12px;
+    }
+    .prompt-actions .category-btn { width: 100%; max-width: 300px; }
+    .pdf-draggable {
+      margin-top: 16px;
+      padding: 10px 14px;
+      border: 1px solid #ccc;
+      border-radius: 6px;
+      background: #f8f9fa;
+      color: #333;
+      cursor: grab;
+      text-align: center;
+      display: inline-block;
+    }
   </style>
 </head>
 <body>
@@ -400,10 +421,27 @@
     </div>
   </div>
 
+  <!-- Modal para generar PDF y copiar prompts -->
+  <div id="pdf-modal" class="info-modal hidden" role="dialog" aria-modal="true" aria-labelledby="pdf-modal-title">
+    <div class="info-content">
+      <div class="info-header">
+        <h3 id="pdf-modal-title">📑 Generar PDF</h3>
+        <button class="close-info" id="close-pdf-modal">×</button>
+      </div>
+      <div class="info-body" id="pdf-modal-body">
+        <div class="category-actions">
+          <button class="category-btn teo" id="pdf-choose-teo">Teoría</button>
+          <button class="category-btn prac" id="pdf-choose-prac">Práctica</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
   <script src="https://unpkg.com/pdfjs-dist@2.16.105/build/pdf.min.js"></script>
   <script>pdfjsLib.GlobalWorkerOptions.workerSrc = 'https://unpkg.com/pdfjs-dist@2.16.105/build/pdf.worker.min.js';</script>
   <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/mathquill/0.10.1/mathquill.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/pdf-lib@1.17.1/dist/pdf-lib.min.js"></script>
 
   <script>
     document.addEventListener('DOMContentLoaded', () => {
@@ -484,6 +522,10 @@
       const chooseTeoBtn = document.getElementById('choose-teo');
       const choosePracBtn = document.getElementById('choose-prac');
 
+      const pdfModal = document.getElementById('pdf-modal');
+      const closePdfModalBtn = document.getElementById('close-pdf-modal');
+      const pdfModalBody = document.getElementById('pdf-modal-body');
+
       let captureMode = false;
       let captureCategory = null; // 'teo' | 'practica'
       let pendingStart = null; // { pageNum, xp, yp, layer }
@@ -491,6 +533,13 @@
 
       let theoryHandle = null;
       let practiceHandle = null;
+
+      const USER_PROMPTS = {
+        resumen: localStorage.getItem('prompt_resumen') || 'Resumen del contenido',
+        vf: localStorage.getItem('prompt_vf') || 'Genera preguntas de verdadero/falso del contenido',
+        reciprocos: localStorage.getItem('prompt_reciprocos') || 'Enumera recíprocos del contenido',
+        practica: localStorage.getItem('prompt_practica') || 'Extraer {"tema","enunciado","ejercicio"}'
+      };
 
       // ========================================
       // UTILIDADES UI
@@ -1094,6 +1143,13 @@
           }
         }
 
+        // NUEVO: Modal prompts Ctrl+M
+        if (e.ctrlKey && e.key.toLowerCase() === 'm' && !e.shiftKey && !e.altKey) {
+          e.preventDefault();
+          openPdfModal();
+          return;
+        }
+
         // NUEVO: Captura Ctrl+I
         if (e.ctrlKey && e.key.toLowerCase() === 'i' && !e.shiftKey && !e.altKey) {
           e.preventDefault();
@@ -1613,6 +1669,9 @@
       closeInfo.addEventListener('click', () => infoModal.classList.add('hidden'));
       infoModal.addEventListener('click', (e) => { if (e.target === infoModal) infoModal.classList.add('hidden'); });
 
+      closePdfModalBtn.addEventListener('click', () => pdfModal.classList.add('hidden'));
+      pdfModal.addEventListener('click', (e) => { if (e.target === pdfModal) pdfModal.classList.add('hidden'); });
+
       // ========================================
       // CAPTURAS: Teoría / Práctica
       // ========================================
@@ -1811,6 +1870,137 @@
           hideOverlay();
           clearAllSelections();
         }
+      }
+
+      // ========================================
+      // PDF desde capturas (Ctrl+M)
+      // ========================================
+      function openPdfModal() {
+        pdfModalBody.innerHTML = `
+          <div class="category-actions">
+            <button class="category-btn teo" id="pdf-choose-teo">Teoría</button>
+            <button class="category-btn prac" id="pdf-choose-prac">Práctica</button>
+          </div>`;
+        pdfModal.classList.remove('hidden');
+        pdfModal.querySelector('#pdf-choose-teo').addEventListener('click', () => handlePdfCategory('teo'));
+        pdfModal.querySelector('#pdf-choose-prac').addEventListener('click', () => handlePdfCategory('practica'));
+      }
+
+      async function handlePdfCategory(cat) {
+        pdfModalBody.innerHTML = '<p>Generando PDF…</p>';
+        try {
+          const pdfData = await generatePdfFromCategory(cat);
+          if (!pdfData) {
+            pdfModalBody.innerHTML = '<p>No se generó PDF.</p>';
+            return;
+          }
+          renderPromptOptions(cat, pdfData);
+        } catch (e) {
+          console.error('Error generando PDF:', e);
+          showToast('Error generando PDF', 'error');
+          pdfModal.classList.add('hidden');
+        }
+      }
+
+      function renderPromptOptions(cat, pdfData) {
+        let html = '';
+        if (cat === 'teo') {
+          html += `<div class="prompt-actions">
+            <button class="category-btn teo" data-prompt="resumen">Resumen</button>
+            <button class="category-btn teo" data-prompt="vf">Verdaderos o falsos</button>
+            <button class="category-btn teo" data-prompt="reciprocos">Recíprocos</button>
+          </div>`;
+        } else {
+          html += `<div class="prompt-actions">
+            <button class="category-btn prac" data-prompt="practica">Extraer {&quot;tema&quot;,&quot;enunciado&quot;,&quot;ejercicio&quot;}</button>
+          </div>`;
+        }
+        html += '<div id="pdf-drop-area"></div>';
+        pdfModalBody.innerHTML = html;
+
+        pdfModalBody.querySelectorAll('[data-prompt]').forEach(btn => {
+          btn.addEventListener('click', async () => {
+            const key = btn.getAttribute('data-prompt');
+            const text = USER_PROMPTS[key] || '';
+            try {
+              await navigator.clipboard.writeText(text);
+              showToast('Prompt copiado', 'success');
+            } catch {
+              showToast('No se pudo copiar', 'error');
+            }
+          });
+        });
+
+        const area = document.getElementById('pdf-drop-area');
+        const link = document.createElement('a');
+        link.className = 'pdf-draggable';
+        link.textContent = pdfData.file.name;
+        link.href = URL.createObjectURL(pdfData.file);
+        link.download = pdfData.file.name;
+        link.draggable = true;
+        link.addEventListener('dragstart', (ev) => {
+          const file = new File([pdfData.blob], pdfData.file.name, { type: 'application/pdf' });
+          ev.dataTransfer?.items.add(file);
+        });
+        area.appendChild(link);
+
+        const testBtn = document.createElement('button');
+        testBtn.textContent = 'Simular archivo';
+        testBtn.addEventListener('click', () => {
+          const input = document.createElement('input');
+          input.type = 'file';
+          input.style.display = 'none';
+          const dt = new DataTransfer();
+          const file = new File([pdfData.blob], pdfData.file.name, { type: 'application/pdf' });
+          dt.items.add(file);
+          input.files = dt.files;
+          document.body.appendChild(input);
+          input.dispatchEvent(new Event('change', { bubbles: true }));
+          input.remove();
+        });
+        area.appendChild(testBtn);
+      }
+
+      async function generatePdfFromCategory(cat) {
+        const handle = await ensureCategoryHandle(cat);
+        if (!handle) return null;
+        const files = [];
+        // @ts-ignore
+        for await (const [name, h] of handle.entries()) {
+          if (h.kind === 'file' && name.toLowerCase().endsWith('.png')) {
+            files.push({ name, handle: h });
+          }
+        }
+        if (!files.length) {
+          showToast('No hay capturas en la carpeta', 'info');
+          return null;
+        }
+        files.sort((a,b) => naturalCompare(a.name, b.name));
+        const pdfDoc = await PDFLib.PDFDocument.create();
+        for (const f of files) {
+          const file = await f.handle.getFile();
+          const url = URL.createObjectURL(file);
+          const dims = await new Promise((resolve, reject) => {
+            const img = new Image();
+            img.onload = () => { resolve({ width: img.naturalWidth, height: img.naturalHeight }); };
+            img.onerror = reject;
+            img.src = url;
+          });
+          URL.revokeObjectURL(url);
+          const bytes = await file.arrayBuffer();
+          const img = await pdfDoc.embedPng(bytes);
+          const page = pdfDoc.addPage([dims.width, dims.height]);
+          page.drawImage(img, { x: 0, y: 0, width: dims.width, height: dims.height });
+        }
+        const pdfBytes = await pdfDoc.save();
+        const blob = new Blob([pdfBytes], { type: 'application/pdf' });
+        const pdfName = cat === 'teo' ? 'teoria.pdf' : 'practica.pdf';
+        const fileHandle = await handle.getFileHandle(pdfName, { create: true });
+        const writable = await fileHandle.createWritable();
+        await writable.write(blob);
+        await writable.close();
+        const file = new File([blob], pdfName, { type: 'application/pdf' });
+        return { handle: fileHandle, file, blob };
       }
 
       // ========================================


### PR DESCRIPTION
## Summary
- add styles and modal to generate PDFs from captured images
- support Ctrl+M to choose Teoría or Práctica and copy prompts
- allow dragging the generated PDF file from the modal
- fix generated PDF to use original capture dimensions
- simulate real file drag and test upload via hidden input

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (prompts to set up ESLint)


------
https://chatgpt.com/codex/tasks/task_e_6899349acaa8833091e33de266d0cec7