### PR TITLE
feat: add study schedule viewer and full-screen pdf

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next'
 import { GeistSans } from 'geist/font/sans'
 import { GeistMono } from 'geist/font/mono'
 import './globals.css'
+import { ThemeProvider } from '@/components/theme-provider'
 
 export const metadata: Metadata = {
   title: 'v0 App',
@@ -15,7 +16,7 @@ export default function RootLayout({
   children: React.ReactNode
 }>) {
   return (
-    <html lang="en">
+    <html lang="es" suppressHydrationWarning>
       <head>
         <style>{`
 html {
@@ -25,7 +26,11 @@ html {
 }
         `}</style>
       </head>
-      <body>{children}</body>
+      <body>
+        <ThemeProvider attribute="class" defaultTheme="light" enableSystem>
+          {children}
+        </ThemeProvider>
+      </body>
     </html>
   )
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,359 +1,728 @@
 "use client"
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react"
-import { Button } from "@/components/ui/button"
-import { Card } from "@/components/ui/card"
-import { Separator } from "@/components/ui/separator"
-import { FolderOpen, Play, ArrowRight, ArrowLeft, Files, Info, RefreshCw } from 'lucide-react'
+import { useEffect, useState } from "react"
+import { useTheme } from "next-themes"
+import * as XLSX from "xlsx"
 
-// Tipos para manejar entradas de PDF de carpeta o como fallback (webkitdirectory)
-type PDFEntry = {
-  name: string
-  handle?: FileSystemFileHandle
-  file?: File
-}
+const days = ["Lunes", "Martes", "Miércoles", "Jueves", "Viernes"]
 
-// Natural sort por nombre de archivo para ordenar 01, 02, 10 correctamente
-function naturalCompare(a: string, b: string) {
-  return a.localeCompare(b, undefined, { numeric: true, sensitivity: "base" })
-}
-
-function isPDF(name: string) {
-  return name.toLowerCase().endsWith(".pdf")
+type PdfFile = {
+  file: File
+  path: string
+  week: number
+  subject: string
+  type: "teoria" | "practica" | null
 }
 
 export default function Home() {
-  const [entries, setEntries] = useState<PDFEntry[]>([])
-  const [currentIndex, setCurrentIndex] = useState<number | null>(null)
-  const [currentPage, setCurrentPage] = useState<number>(1)
-  const [totalPages, setTotalPages] = useState<number>(0)
-  const [loadingDoc, setLoadingDoc] = useState(false)
-  const [loadingPage, setLoadingPage] = useState(false)
-  const [error, setError] = useState<string | null>(null)
+  const { setTheme } = useTheme()
+  const [started, setStarted] = useState(false)
+  const [setupComplete, setSetupComplete] = useState(true)
+  const [step, setStep] = useState(1)
+  const [files, setFiles] = useState<File[]>([])
+  const [names, setNames] = useState<string[]>([])
+  const [theory, setTheory] = useState<Record<string, string>>({})
+  const [practice, setPractice] = useState<Record<string, string>>({})
+  const [folderReady, setFolderReady] = useState(false)
+  const [weeks, setWeeks] = useState(1)
+  const [dirFiles, setDirFiles] = useState<File[]>([])
+  const [fileTree, setFileTree] = useState<Record<number, Record<string, PdfFile[]>>>({})
+  const [completed, setCompleted] = useState<Record<string, boolean>>({})
+  const [tags, setTags] = useState<Record<string, "teoria" | "practica">>({})
+  const [currentPdf, setCurrentPdf] = useState<PdfFile | null>(null)
+  const [queue, setQueue] = useState<PdfFile[]>([])
+  const [queueIndex, setQueueIndex] = useState(0)
+  const [viewWeek, setViewWeek] = useState<number | null>(null)
+  const [viewSubject, setViewSubject] = useState<string | null>(null)
+  const [pdfUrl, setPdfUrl] = useState<string | null>(null)
+  const [viewerOpen, setViewerOpen] = useState(false)
+  const [showSchedule, setShowSchedule] = useState(false)
+  const [scheduleFilter, setScheduleFilter] = useState<string>("")
+  const [selectedDay, setSelectedDay] = useState<string>("")
 
-  // refs para PDF.js y canvas
-  const pdfLibRef = useRef<any>(null)
-  const pdfDocRef = useRef<any>(null)
-  const cancelRenderRef = useRef<(() => void) | null>(null)
-  const containerRef = useRef<HTMLDivElement | null>(null)
-  const canvasRef = useRef<HTMLCanvasElement | null>(null)
-  const inputDirRef = useRef<HTMLInputElement | null>(null)
-
-  // Preparar input webkitdirectory como alternativa si showDirectoryPicker no está disponible
+  // theme and setup flag
   useEffect(() => {
-    if (inputDirRef.current) {
-      // Algunos navegadores necesitan este atributo para permitir seleccionar carpetas
-      inputDirRef.current.setAttribute("webkitdirectory", "")
-      inputDirRef.current.setAttribute("directory", "")
+    const hour = new Date().getHours()
+    if (hour >= 19 || hour < 6) {
+      setTheme("dark")
+    } else {
+      setTheme("light")
     }
+    const stored = localStorage.getItem("setupComplete")
+    if (!stored) {
+      setSetupComplete(false)
+    } else {
+      const storedWeeks = parseInt(localStorage.getItem("weeks") || "1")
+      setWeeks(storedWeeks)
+      const storedNames = localStorage.getItem("names")
+      if (storedNames) setNames(JSON.parse(storedNames))
+      const storedTheory = localStorage.getItem("theory")
+      if (storedTheory) setTheory(JSON.parse(storedTheory))
+      const storedPractice = localStorage.getItem("practice")
+      if (storedPractice) setPractice(JSON.parse(storedPractice))
+    }
+  }, [setTheme])
+
+  // greeting handler
+  useEffect(() => {
+    const handler = () => setStarted(true)
+    if (!started) {
+      window.addEventListener("keydown", handler)
+      return () => window.removeEventListener("keydown", handler)
+    }
+  }, [started])
+
+  // load completed from storage
+  useEffect(() => {
+    const stored = localStorage.getItem("completed")
+    if (stored) setCompleted(JSON.parse(stored))
   }, [])
 
-  // Cargar PDF.js de forma dinámica para evitar problemas de worker y SSR
+  // load tags
   useEffect(() => {
-    let mounted = true
-    const load = async () => {
-      try {
-        const pdfjsLib = await import("pdfjs-dist/build/pdf")
-        // Ajusta la versión si lo prefieres (probada)
-        pdfjsLib.GlobalWorkerOptions.workerSrc =
-          "https://unpkg.com/pdfjs-dist@2.16.105/build/pdf.worker.min.js"
-        if (mounted) {
-          pdfLibRef.current = pdfjsLib
+    const stored = localStorage.getItem("tags")
+    if (stored) setTags(JSON.parse(stored))
+  }, [])
+
+  // persist completed
+  useEffect(() => {
+    localStorage.setItem("completed", JSON.stringify(completed))
+  }, [completed])
+
+  useEffect(() => {
+    localStorage.setItem("tags", JSON.stringify(tags))
+  }, [tags])
+
+  // build tree from selected directory
+  useEffect(() => {
+    const tree: Record<number, Record<string, PdfFile[]>> = {}
+    for (const file of dirFiles) {
+      const parts = (file as any).webkitRelativePath?.split("/") || []
+      if (parts.length >= 3 && file.name.toLowerCase().endsWith(".pdf")) {
+        const weekMatch = parts[0].match(/\d+/)
+        const week = weekMatch ? parseInt(weekMatch[0]) : 1
+        const subject = parts[1]
+        if (!tree[week]) tree[week] = {}
+        if (!tree[week][subject]) tree[week][subject] = []
+        const key = parts.join("/")
+        tree[week][subject].push({
+          file,
+          path: key,
+          week,
+          subject,
+          type: tags[key] || null,
+        })
+      }
+    }
+    for (const w in tree) {
+      for (const s in tree[w]) {
+        tree[w][s].sort((a, b) => a.file.name.localeCompare(b.file.name))
+      }
+    }
+    setFileTree(tree)
+  }, [dirFiles, tags])
+
+  // compute queue ordered by urgency
+  useEffect(() => {
+    const dayMap: Record<string, number> = {
+      Lunes: 1,
+      Martes: 2,
+      Miércoles: 3,
+      Jueves: 4,
+      Viernes: 5,
+    }
+    const today = new Date().getDay()
+    const stats: { subject: string; days: number; pdfs: PdfFile[] }[] = []
+    Object.values(fileTree).forEach((subjects) => {
+      Object.entries(subjects).forEach(([subject, files]) => {
+        const remaining = files.filter((f) => !completed[f.path])
+        if (!remaining.length) return
+        let days = 7
+        const t = theory[subject]
+        const p = practice[subject]
+        const candidates = [t, p]
+          .filter((d): d is string => !!d)
+          .map((d) => dayMap[d])
+        if (candidates.length) {
+          days = Math.min(
+            ...candidates.map((d) => {
+              let diff = d - today
+              if (diff < 0) diff += 7
+              if (diff === 0) diff = 7
+              return diff
+            }),
+          )
         }
-      } catch (e: any) {
-        console.error("Error cargando PDF.js:", e)
-        setError("No se pudo cargar el motor PDF")
-      }
-    }
-    load()
-    return () => {
-      mounted = false
-    }
-  }, [])
-
-  // Orden visible de archivos
-  const orderedEntries = useMemo(() => {
-    return [...entries].sort((a, b) => naturalCompare(a.name, b.name))
-  }, [entries])
-
-  const currentFileName = useMemo(() => {
-    if (currentIndex == null) return null
-    return orderedEntries[currentIndex]?.name ?? null
-  }, [currentIndex, orderedEntries])
-
-  const resetViewer = useCallback(async () => {
-    // Cancelar render en curso
-    if (cancelRenderRef.current) {
-      try {
-        cancelRenderRef.current()
-      } catch {}
-      cancelRenderRef.current = null
-    }
-    // Destruir doc actual
-    if (pdfDocRef.current) {
-      try {
-        await pdfDocRef.current.destroy()
-      } catch {}
-      pdfDocRef.current = null
-    }
-    setTotalPages(0)
-    setCurrentPage(1)
-  }, [])
-
-  const pickFolder = useCallback(async () => {
-    setError(null)
-    setEntries([])
-    setCurrentIndex(null)
-    try {
-      // @ts-expect-error: showDirectoryPicker puede no existir en TS pero sí en runtime
-      if (!window.showDirectoryPicker) {
-        // Fallback: disparar input webkitdirectory
-        inputDirRef.current?.click()
-        return
-      }
-
-      const dirHandle: FileSystemDirectoryHandle = await (window as any).showDirectoryPicker({
-        mode: "read"
+        stats.push({ subject, days, pdfs: remaining })
       })
+    })
+    stats.sort((a, b) => {
+      if (a.days !== b.days) return a.days - b.days
+      return b.pdfs.length - a.pdfs.length
+    })
+    const q: PdfFile[] = []
+    stats.forEach((s) => {
+      q.push(
+        ...s.pdfs.sort((a, b) => a.week - b.week || a.file.name.localeCompare(b.file.name)),
+      )
+    })
+    setQueue(q)
+    if (q.length) {
+      const current = currentPdf && q.find((f) => f.path === currentPdf.path)
+      const target = current || q[0]
+      setCurrentPdf(target)
+      setQueueIndex(q.findIndex((f) => f.path === target.path))
+    } else {
+      setCurrentPdf(null)
+      setQueueIndex(0)
+    }
+  }, [fileTree, completed, theory, practice])
 
-      const found: PDFEntry[] = []
-      // Recorrer solo el primer nivel de la carpeta
-      // @ts-ignore: TypeScript no conoce correctamente entries() asíncrono
-      for await (const [name, handle] of (dirHandle as any).entries()) {
-        if (handle.kind === "file" && isPDF(name)) {
-          found.push({ name, handle })
+  // object url for viewer
+  useEffect(() => {
+    if (currentPdf) {
+      const url = URL.createObjectURL(currentPdf.file)
+      setPdfUrl(url)
+      return () => URL.revokeObjectURL(url)
+    }
+    setPdfUrl(null)
+  }, [currentPdf])
+
+  // greeting screen
+  if (!started) {
+    const hour = new Date().getHours()
+    const greeting = hour >= 19 || hour < 6 ? "Buenas noches" : "Buenos días"
+    return (
+      <main className="min-h-screen flex items-center justify-center text-2xl">
+        <p>{greeting}. Presiona cualquier tecla para continuar.</p>
+      </main>
+    )
+  }
+
+  // configuration wizard
+  if (!setupComplete) {
+    switch (step) {
+      case 1: {
+        const handleConfirm = async () => {
+          let maxWeek = 1
+          for (const file of files) {
+            const buffer = await file.arrayBuffer()
+            const wb = XLSX.read(buffer)
+            const sheet = wb.Sheets[wb.SheetNames[0]]
+            const rows = XLSX.utils.sheet_to_json<Record<string, any>>(sheet)
+            rows.forEach((r) => {
+              const w = parseInt(r["SEMANA"])
+              if (!isNaN(w) && w > maxWeek) maxWeek = w
+            })
+          }
+          setWeeks(maxWeek)
+          setNames(files.map(() => ""))
+          setStep(2)
         }
+        return (
+          <main className="min-h-screen flex flex-col items-center justify-center gap-4 p-4">
+            <h1 className="text-xl">Comencemos a configurar el entorno</h1>
+            <p>Paso 1: Sube tus cronogramas (excel)</p>
+            <input
+              type="file"
+              accept=".xlsx,.xls"
+              multiple
+              onChange={(e) => setFiles(Array.from(e.target.files || []))}
+            />
+            <button
+              className="px-4 py-2 border rounded"
+              disabled={!files.length}
+              onClick={handleConfirm}
+            >
+              Confirmar
+            </button>
+          </main>
+        )
       }
-
-      if (!found.length) {
-        setError("La carpeta no contiene archivos PDF.")
-        return
-      }
-
-      setEntries(found)
-    } catch (e: any) {
-      if (e?.name === "AbortError") return
-      console.error(e)
-      setError("No se pudo acceder a la carpeta.")
-    }
-  }, [])
-
-  const onFallbackFolder = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
-    setError(null)
-    const files = Array.from(e.target.files ?? []).filter((f) => isPDF(f.name))
-    if (!files.length) {
-      setError("La carpeta seleccionada no contiene PDFs.")
-      return
-    }
-    const list: PDFEntry[] = files.map((f) => ({ name: f.name, file: f }))
-    setEntries(list)
-  }, [])
-
-  // Cargar un PDF por índice
-  const loadPdfByIndex = useCallback(
-    async (index: number) => {
-      if (index < 0 || index >= orderedEntries.length) return
-      if (!pdfLibRef.current) {
-        setError("PDF.js aún no está listo.")
-        return
-      }
-      setLoadingDoc(true)
-      setError(null)
-      await resetViewer()
-
-      try {
-        const entry = orderedEntries[index]
-        let arrayBuffer: ArrayBuffer
-        if (entry.handle) {
-          const file = await entry.handle.getFile()
-          arrayBuffer = await file.arrayBuffer()
-        } else if (entry.file) {
-          arrayBuffer = await entry.file.arrayBuffer()
-        } else {
-          throw new Error("Entrada de PDF inválida.")
+      case 2: {
+        const updateName = (idx: number, value: string) => {
+          const next = [...names]
+          next[idx] = value
+          setNames(next)
         }
-
-        const loadingTask = pdfLibRef.current.getDocument({ data: arrayBuffer })
-        const pdf = await loadingTask.promise
-        pdfDocRef.current = pdf
-        setCurrentIndex(index)
-        setTotalPages(pdf.numPages)
-        setCurrentPage(1)
-      } catch (e: any) {
-        console.error("Error cargando PDF:", e)
-        setError("No se pudo abrir el PDF.")
-      } finally {
-        setLoadingDoc(false)
+        return (
+          <main className="min-h-screen flex flex-col items-center justify-center gap-4 p-4">
+            <p>Paso 2: Nombra tus cronogramas</p>
+            {files.map((f, i) => (
+              <label key={i} className="flex gap-2 items-center">
+                <span>{f.name} es de</span>
+                <input
+                  className="border p-1"
+                  value={names[i] || ""}
+                  onChange={(e) => updateName(i, e.target.value)}
+                />
+              </label>
+            ))}
+            <button
+              className="px-4 py-2 border rounded"
+              disabled={names.some((n) => !n)}
+              onClick={() => setStep(3)}
+            >
+              Confirmar
+            </button>
+          </main>
+        )
       }
-    },
-    [orderedEntries, resetViewer]
-  )
-
-  // Renderizar una página actual cuando cambie el PDF, la página o el tamaño
-  const renderCurrentPage = useCallback(async () => {
-    if (!pdfDocRef.current || !canvasRef.current || !containerRef.current) return
-    if (!currentPage) return
-
-    setLoadingPage(true)
-    setError(null)
-
-    // Cancelación simple: cambiar flag local si llega una nueva renderización
-    let cancelled = false
-    cancelRenderRef.current = () => {
-      cancelled = true
-    }
-
-    try {
-      const page = await pdfDocRef.current.getPage(currentPage)
-      if (cancelled) return
-
-      const containerWidth = Math.max(320, containerRef.current.clientWidth)
-      const baseViewport = page.getViewport({ scale: 1 })
-      // Fit width
-      const scale = Math.max(0.5, Math.min(2.5, (containerWidth - 24) / baseViewport.width))
-      const viewport = page.getViewport({ scale })
-
-      const canvas = canvasRef.current
-      const ctx = canvas.getContext("2d")
-      if (!ctx) throw new Error("Canvas no disponible")
-
-      const ratio = window.devicePixelRatio || 1
-      canvas.width = Math.floor(viewport.width * ratio)
-      canvas.height = Math.floor(viewport.height * ratio)
-      canvas.style.width = `${viewport.width}px`
-      canvas.style.height = `${viewport.height}px`
-
-      ctx.setTransform(ratio, 0, 0, ratio, 0, 0)
-      const renderTask = page.render({
-        canvasContext: ctx,
-        viewport
-      })
-      await renderTask.promise
-
-      if (!cancelled) {
-        // ok
+      case 3: {
+        const unassigned = names.filter((n) => !theory[n])
+        const handleDrop = (subject: string, day: string) => {
+          setTheory({ ...theory, [subject]: day })
+        }
+        return (
+          <main className="min-h-screen flex flex-col items-center gap-4 p-4">
+            <p>Paso 3: Arrastra tus materias (teoría) a los días</p>
+            <div className="flex gap-4">
+              <div className="w-40 border p-2 min-h-40">
+                {unassigned.map((s) => (
+                  <div
+                    key={s}
+                    draggable
+                    onDragStart={(e) => e.dataTransfer.setData("text", s)}
+                    className="p-1 mb-2 bg-green-500 text-white cursor-move"
+                  >
+                    {s}
+                  </div>
+                ))}
+              </div>
+              {days.map((d) => (
+                <div
+                  key={d}
+                  onDragOver={(e) => e.preventDefault()}
+                  onDrop={(e) => handleDrop(e.dataTransfer.getData("text"), d)}
+                  className="border p-2 w-32 min-h-40"
+                >
+                  <div className="font-bold">{d}</div>
+                  {Object.entries(theory)
+                    .filter(([_, day]) => day === d)
+                    .map(([s]) => (
+                      <div key={s} className="p-1 mt-2 bg-green-200">
+                        {s}
+                      </div>
+                    ))}
+                </div>
+              ))}
+            </div>
+            {unassigned.length === 0 && (
+              <button
+                className="px-4 py-2 border rounded"
+                onClick={() => {
+                  setStep(4)
+                }}
+              >
+                Confirmar
+              </button>
+            )}
+          </main>
+        )
       }
-    } catch (e: any) {
-      if (!cancelled) {
-        console.error("Error renderizando página:", e)
-        setError("No se pudo renderizar la página.")
+      case 4: {
+        const unassigned = names.filter((n) => !practice[n])
+        const handleDrop = (subject: string, day: string) => {
+          setPractice({ ...practice, [subject]: day })
+        }
+        return (
+          <main className="min-h-screen flex flex-col items-center gap-4 p-4">
+            <p>Paso 3: Arrastra tus materias (práctica) a los días</p>
+            <div className="flex gap-4">
+              <div className="w-40 border p-2 min-h-40">
+                {unassigned.map((s) => (
+                  <div
+                    key={s}
+                    draggable
+                    onDragStart={(e) => e.dataTransfer.setData("text", s)}
+                    className="p-1 mb-2 bg-blue-500 text-white cursor-move"
+                  >
+                    {s}
+                  </div>
+                ))}
+              </div>
+              {days.map((d) => (
+                <div
+                  key={d}
+                  onDragOver={(e) => e.preventDefault()}
+                  onDrop={(e) => handleDrop(e.dataTransfer.getData("text"), d)}
+                  className="border p-2 w-32 min-h-40"
+                >
+                  <div className="font-bold">{d}</div>
+                  {Object.entries(practice)
+                    .filter(([_, day]) => day === d)
+                    .map(([s]) => (
+                      <div key={s} className="p-1 mt-2 bg-blue-200">
+                        {s}
+                      </div>
+                    ))}
+                </div>
+              ))}
+            </div>
+            {unassigned.length === 0 && (
+              <button
+                className="px-4 py-2 border rounded"
+                onClick={() => setStep(5)}
+              >
+                Confirmar
+              </button>
+            )}
+          </main>
+        )
       }
-    } finally {
-      if (!cancelled) setLoadingPage(false)
-    }
-  }, [currentPage])
-
-  // Re-render cuando cambien dependencias clave
-  useEffect(() => {
-    renderCurrentPage()
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [renderCurrentPage, totalPages, currentIndex])
-
-  // Re-render al redimensionar
-  useEffect(() => {
-    const onResize = () => {
-      renderCurrentPage()
-    }
-    window.addEventListener("resize", onResize)
-    return () => window.removeEventListener("resize", onResize)
-  }, [renderCurrentPage])
-
-  // Navegación entre páginas y PDFs
-  const canStart = entries.length > 0
-  const hasDoc = currentIndex != null && pdfDocRef.current
-  const canPrev =
-    hasDoc && (currentPage > 1 || (currentPage === 1 && (currentIndex ?? 0) > 0))
-  const canNext =
-    hasDoc &&
-    (currentPage < totalPages ||
-      (currentPage === totalPages && (currentIndex ?? 0) < orderedEntries.length - 1))
-
-  const goStart = useCallback(() => {
-    if (!canStart) return
-    loadPdfByIndex(0)
-  }, [canStart, loadPdfByIndex])
-
-  const goPrev = useCallback(async () => {
-    if (!hasDoc) return
-    // Si no estamos en la primera página, retroceder página
-    if (currentPage > 1) {
-      setCurrentPage((p) => p - 1)
-      return
-    }
-    // Si estamos en la primera página, ir al PDF anterior y saltar a su última página
-    const prevIndex = (currentIndex as number) - 1
-    if (prevIndex >= 0) {
-      await loadPdfByIndex(prevIndex)
-      // Esperar a que se ajuste totalPages
-      setTimeout(() => {
-        setCurrentPage((_) => (pdfDocRef.current ? pdfDocRef.current.numPages : 1))
-      }, 0)
-    }
-  }, [hasDoc, currentPage, currentIndex, loadPdfByIndex])
-
-  const goNext = useCallback(async () => {
-    if (!hasDoc) return
-    // Si no estamos en la última página, avanzar página
-    if (currentPage < totalPages) {
-      setCurrentPage((p) => p + 1)
-      return
-    }
-    // Si estamos en la última página, ir al siguiente PDF y saltar a su primera página
-    const nextIndex = (currentIndex as number) + 1
-    if (nextIndex < orderedEntries.length) {
-      await loadPdfByIndex(nextIndex)
-      // Primera página por defecto
-    }
-  }, [hasDoc, currentPage, totalPages, currentIndex, orderedEntries.length, loadPdfByIndex])
-
-  // Atajos de teclado: ← y → cruzan PDFs según el estado
-  useEffect(() => {
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "ArrowLeft") {
-        e.preventDefault()
-        if (canPrev) goPrev()
-      }
-      if (e.key === "ArrowRight") {
-        e.preventDefault()
-        if (canNext) goNext()
+      case 5: {
+        const finish = () => {
+          localStorage.setItem("setupComplete", "1")
+          localStorage.setItem("weeks", String(weeks))
+          localStorage.setItem("names", JSON.stringify(names))
+          localStorage.setItem("theory", JSON.stringify(theory))
+          localStorage.setItem("practice", JSON.stringify(practice))
+          setSetupComplete(true)
+          setStarted(false)
+        }
+        return (
+          <main className="min-h-screen flex flex-col items-center justify-center gap-4 p-4">
+            <p>Paso 4: Da acceso a la carpeta "gestor"</p>
+            <input
+              type="file"
+              // @ts-expect-error webkitdirectory es no estándar
+              webkitdirectory=""
+              onChange={(e) => {
+                setDirFiles(Array.from(e.target.files || []))
+                setFolderReady(true)
+              }}
+            />
+            <button
+              className="px-4 py-2 border rounded"
+              disabled={!folderReady}
+              onClick={finish}
+            >
+              Finalizar
+            </button>
+          </main>
+        )
       }
     }
-    window.addEventListener("keydown", onKey)
-    return () => window.removeEventListener("keydown", onKey)
-  }, [canPrev, canNext, goPrev, goNext])
+  }
 
-  const selectedCount = entries.length
-  const hintText =
-    "Usa ← y → para avanzar y retroceder. En la última página de un PDF saltas al siguiente; en la primera, al anterior."
+  const handleSelectPdf = (pdf: PdfFile) => {
+    let tagged = tags[pdf.path]
+    if (!tagged) {
+      const t = window.prompt("Etiqueta para PDF (teoria/practica)", "teoria")
+      if (t && t.toLowerCase().startsWith("p")) tagged = "practica"
+      else tagged = "teoria"
+      setTags((prev) => ({ ...prev, [pdf.path]: tagged! }))
+    }
+    pdf.type = tagged || null
+    const idx = queue.findIndex((f) => f.path === pdf.path)
+    if (idx >= 0) {
+      setQueueIndex(idx)
+      setCurrentPdf(queue[idx])
+    } else {
+      setCurrentPdf(pdf)
+    }
+    setViewerOpen(true)
+  }
 
+  const getDaysRemaining = (pdf: PdfFile) => {
+    const dayMap: Record<string, number> = {
+      Lunes: 1,
+      Martes: 2,
+      Miércoles: 3,
+      Jueves: 4,
+      Viernes: 5,
+    }
+    const today = new Date().getDay()
+    const targetName =
+      pdf.type === "practica" ? practice[pdf.subject] : theory[pdf.subject]
+    if (!targetName) return null
+    let diff = dayMap[targetName] - today
+    if (diff <= 0) diff += 7
+    return diff
+  }
+
+  const prevPdf = () => {
+    if (queueIndex > 0) {
+      const i = queueIndex - 1
+      setQueueIndex(i)
+      setCurrentPdf(queue[i])
+    }
+  }
+
+  const nextPdf = () => {
+    if (queueIndex < queue.length - 1) {
+      const i = queueIndex + 1
+      setQueueIndex(i)
+      setCurrentPdf(queue[i])
+    }
+  }
+
+  const movePdf = (week: number, subject: string, index: number, dir: number) => {
+    setFileTree((prev) => {
+      const copy = { ...prev }
+      const arr = [...(copy[week]?.[subject] || [])]
+      const newIdx = index + dir
+      if (newIdx < 0 || newIdx >= arr.length) return prev
+      const [item] = arr.splice(index, 1)
+      arr.splice(newIdx, 0, item)
+      copy[week][subject] = arr
+      return { ...copy }
+    })
+  }
+
+  const toggleComplete = () => {
+    if (!currentPdf) return
+    const key = currentPdf.path
+    setCompleted((prev) => ({ ...prev, [key]: !prev[key] }))
+  }
+
+  // main interface
   return (
-    <main className="min-h-screen">
-      <iframe
-        title="Visor PDF avanzado"
-        src="/visor/index.html"
-        className="w-full h-screen border-0"
-      />
+    <main className="grid grid-cols-2 min-h-screen">
+      <aside className="border-r p-4 space-y-2 overflow-y-auto">
+        <button
+          className="underline"
+          onClick={() => setShowSchedule((s) => !s)}
+        >
+          {showSchedule ? "Ocultar cronograma" : "Ver cronograma"}
+        </button>
+        {showSchedule && (
+          <div className="mb-4">
+            <select
+              className="border p-1 mb-2"
+              value={scheduleFilter}
+              onChange={(e) => setScheduleFilter(e.target.value)}
+            >
+              <option value="">Todas</option>
+              {names.map((n) => (
+                <option key={n}>{n}</option>
+              ))}
+            </select>
+            <div className="space-y-2">
+              {days.map((d) => (
+                <div key={d}>
+                  <div className="font-bold">{d}</div>
+                  <div className="flex flex-wrap gap-2">
+                    {names
+                      .filter(
+                        (n) =>
+                          (!scheduleFilter || scheduleFilter === n) &&
+                          (theory[n] === d || practice[n] === d),
+                      )
+                      .map((n) => {
+                        const colorIdx = names.indexOf(n)
+                        return (
+                          <span
+                            key={n}
+                            className="px-2 py-1 text-white rounded-full text-sm"
+                            style={{
+                              backgroundColor: [
+                                "#f87171",
+                                "#60a5fa",
+                                "#34d399",
+                                "#fbbf24",
+                                "#c084fc",
+                              ][colorIdx % 5],
+                            }}
+                          >
+                            {n}
+                          </span>
+                        )
+                      })}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+        {!viewWeek && (
+          <>
+            <h2 className="text-xl">Semanas</h2>
+            <ul className="space-y-1">
+              {Array.from({ length: weeks }, (_, i) => {
+                const wk = i + 1
+                const locked = wk > 1
+                return (
+                  <li key={wk} className={locked ? "opacity-50" : "font-bold"}>
+                    {locked ? (
+                      <>Semana {wk} 🔒</>
+                    ) : (
+                      <button onClick={() => setViewWeek(wk)}>Semana {wk}</button>
+                    )}
+                  </li>
+                )
+              })}
+            </ul>
+          </>
+        )}
+        {viewWeek && !viewSubject && (
+          <>
+            <button className="mb-2 underline" onClick={() => setViewWeek(null)}>
+              ← Volver
+            </button>
+            <h2 className="text-xl">Semana {viewWeek}</h2>
+            <ul className="space-y-1">
+              {Object.keys(fileTree[viewWeek] || {}).map((s) => {
+                const files = fileTree[viewWeek]?.[s] || []
+                const done = files.filter((f) => completed[f.path]).length
+                const percent = files.length
+                  ? Math.round((done / files.length) * 100)
+                  : 0
+                return (
+                  <li key={s}>
+                    <button onClick={() => setViewSubject(s)}>
+                      {s} ({percent}%)
+                    </button>
+                  </li>
+                )
+              })}
+            </ul>
+          </>
+        )}
+        {viewWeek && viewSubject && (
+          <>
+            <button className="mb-2 underline" onClick={() => setViewSubject(null)}>
+              ← Volver
+            </button>
+            <h2 className="text-xl">{viewSubject}</h2>
+            <ul className="space-y-1">
+              {(fileTree[viewWeek]?.[viewSubject] || []).map((p, i) => (
+                <li
+                  key={p.path}
+                  className={`flex items-center gap-2 cursor-pointer ${
+                    completed[p.path] ? "line-through text-gray-400" : ""
+                  }`}
+                >
+                  <span
+                    className="flex-1 truncate"
+                    title={p.file.name}
+                    onClick={() => handleSelectPdf(p)}
+                  >
+                    {p.file.name}
+                  </span>
+                  <button onClick={() => movePdf(viewWeek!, viewSubject!, i, -1)}>
+                    ↑
+                  </button>
+                  <button onClick={() => movePdf(viewWeek!, viewSubject!, i, 1)}>
+                    ↓
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </>
+        )}
+      </aside>
+      <section className="flex flex-col h-screen">
+        <div className="flex items-center justify-between p-2 border-b">
+          <div className="flex items-center gap-2">
+            <span>📄</span>
+            <span className="truncate max-w-xs" title={currentPdf?.file.name}>
+              {currentPdf ? currentPdf.file.name : "Sin selección"}
+            </span>
+          </div>
+          <div className="flex items-center gap-2">
+            <button onClick={prevPdf} disabled={queueIndex <= 0}>
+              ←
+            </button>
+            <button onClick={nextPdf} disabled={queueIndex >= queue.length - 1}>
+              →
+            </button>
+            {currentPdf && (
+              <input
+                type="checkbox"
+                checked={!!completed[currentPdf.path]}
+                onChange={toggleComplete}
+              />
+            )}
+          </div>
+        </div>
+        <div className="flex-1 flex flex-col">
+          {/* Listado por día */}
+          <div className="p-2 flex gap-2 border-b">
+            <select
+              className="border p-1"
+              value={selectedDay}
+              onChange={(e) => setSelectedDay(e.target.value)}
+            >
+              <option value="">Día</option>
+              {days.map((d) => (
+                <option key={d}>{d}</option>
+              ))}
+            </select>
+            <select
+              className="border p-1"
+              value={scheduleFilter}
+              onChange={(e) => setScheduleFilter(e.target.value)}
+            >
+              <option value="">Materia</option>
+              {names.map((n) => (
+                <option key={n}>{n}</option>
+              ))}
+            </select>
+          </div>
+          <div className="p-2 space-y-1 overflow-y-auto flex-1">
+            {selectedDay &&
+              (scheduleFilter
+                ? [scheduleFilter]
+                : names.filter(
+                    (n) =>
+                      theory[n] === selectedDay || practice[n] === selectedDay,
+                  )
+              ).map((sub) => {
+                const pending = Object.values(fileTree)
+                  .flatMap((subs) => subs[sub] || [])
+                  .filter((p) => !completed[p.path])
+                if (!pending.length) return null
+                return (
+                  <div key={sub} className="border p-2">
+                    <div className="font-bold mb-1">{sub}</div>
+                    <div>{pending[0].file.name}</div>
+                  </div>
+                )
+              })}
+          </div>
+        </div>
+      </section>
+      {viewerOpen && currentPdf && (
+        <div className="fixed inset-0 flex flex-col bg-black z-50">
+          <div className="flex items-center justify-between p-2 text-white bg-gray-800">
+            <button onClick={() => setViewerOpen(false)}>←</button>
+            <div
+              className="flex-1 text-center truncate px-2"
+              title={currentPdf.file.name}
+            >
+              {currentPdf.file.name}
+            </div>
+            <div className="flex items-center gap-2">
+              <button onClick={prevPdf} disabled={queueIndex <= 0}>
+                ←
+              </button>
+              <button onClick={nextPdf} disabled={queueIndex >= queue.length - 1}>
+                →
+              </button>
+              <input
+                type="checkbox"
+                checked={!!completed[currentPdf.path]}
+                onChange={toggleComplete}
+              />
+            </div>
+          </div>
+          <iframe
+            className="flex-1 w-full"
+            title="Visor"
+            src={`/visor/index.html?url=${encodeURIComponent(
+              pdfUrl || "",
+            )}&name=${encodeURIComponent(currentPdf.file.name)}`}
+          />
+          <div className="p-2 text-center text-white bg-gray-800">
+            {(() => {
+              const d = getDaysRemaining(currentPdf)
+              return d !== null ? `Días restantes: ${d}` : ""
+            })()}
+          </div>
+        </div>
+      )}
     </main>
   )
 }
 
-/**
- * Pequeño helper para disparar efectos imperativos cuando un "when" cambia,
- * sin forzar re-render del componente principal.
- */
-function RenderEffect({
-  when,
-  onEffect
-}: {
-  when: string | number | boolean
-  onEffect: () => void
-}) {
-  const prev = useRef<string | number | boolean | null>(null)
-  useEffect(() => {
-    if (prev.current !== when) {
-      prev.current = when
-      onEffect()
-    }
-  }, [when, onEffect])
-  return null
-}

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "tailwind-merge": "^2.5.5",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^0.9.9",
+    "xlsx": "0.18.5",
     "zod": "3.25.67"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -158,6 +158,9 @@ importers:
       vaul:
         specifier: ^0.9.9
         version: 0.9.9(@types/react-dom@19.0.0)(@types/react@19.0.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      xlsx:
+        specifier: 0.18.5
+        version: 0.18.5
       zod:
         specifier: 3.25.67
         version: 3.25.67
@@ -1250,6 +1253,10 @@ packages:
   '@types/react@19.0.0':
     resolution: {integrity: sha512-MY3oPudxvMYyesqs/kW1Bh8y9VqSmf+tzqw3ae8a9DZW68pUe3zAdHeI1jc6iAysuRdACnVknHP8AhwD4/dxtg==}
 
+  adler-32@1.3.1:
+    resolution: {integrity: sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==}
+    engines: {node: '>=0.8'}
+
   aria-hidden@1.2.6:
     resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
     engines: {node: '>=10'}
@@ -1273,6 +1280,10 @@ packages:
   caniuse-lite@1.0.30001733:
     resolution: {integrity: sha512-e4QKw/O2Kavj2VQTKZWrwzkt3IxOmIlU6ajRb6LP64LHpBo1J67k2Hi4Vu/TgJWsNtynurfS0uK3MaUTCPfu5Q==}
 
+  cfb@1.2.2:
+    resolution: {integrity: sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==}
+    engines: {node: '>=0.8'}
+
   chownr@3.0.0:
     resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
     engines: {node: '>=18'}
@@ -1293,6 +1304,10 @@ packages:
       react: ^18 || ^19 || ^19.0.0-rc
       react-dom: ^18 || ^19 || ^19.0.0-rc
 
+  codepage@1.15.0:
+    resolution: {integrity: sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==}
+    engines: {node: '>=0.8'}
+
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
@@ -1306,6 +1321,11 @@ packages:
   color@4.2.3:
     resolution: {integrity: sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==}
     engines: {node: '>=12.5.0'}
+
+  crc-32@1.2.2:
+    resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
+    engines: {node: '>=0.8'}
+    hasBin: true
 
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
@@ -1403,6 +1423,10 @@ packages:
   fast-equals@5.2.2:
     resolution: {integrity: sha512-V7/RktU11J3I36Nwq2JnZEM7tNm17eBJz+u25qdxBZeCKiX6BkVSZQjwWIr+IobgnZy+ag73tTZgZi7tr0LrBw==}
     engines: {node: '>=6.0.0'}
+
+  frac@1.1.2:
+    resolution: {integrity: sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==}
+    engines: {node: '>=0.8'}
 
   fraction.js@4.3.7:
     resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}
@@ -1705,6 +1729,10 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
+  ssf@0.11.2:
+    resolution: {integrity: sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==}
+    engines: {node: '>=0.8'}
+
   streamsearch@1.1.0:
     resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
     engines: {node: '>=10.0.0'}
@@ -1797,6 +1825,19 @@ packages:
 
   victory-vendor@36.9.2:
     resolution: {integrity: sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==}
+
+  wmf@1.0.2:
+    resolution: {integrity: sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==}
+    engines: {node: '>=0.8'}
+
+  word@0.3.0:
+    resolution: {integrity: sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==}
+    engines: {node: '>=0.8'}
+
+  xlsx@0.18.5:
+    resolution: {integrity: sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==}
+    engines: {node: '>=0.8'}
+    hasBin: true
 
   yallist@5.0.0:
     resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
@@ -2813,6 +2854,8 @@ snapshots:
     dependencies:
       csstype: 3.1.3
 
+  adler-32@1.3.1: {}
+
   aria-hidden@1.2.6:
     dependencies:
       tslib: 2.8.1
@@ -2840,6 +2883,11 @@ snapshots:
 
   caniuse-lite@1.0.30001733: {}
 
+  cfb@1.2.2:
+    dependencies:
+      adler-32: 1.3.1
+      crc-32: 1.2.2
+
   chownr@3.0.0: {}
 
   class-variance-authority@0.7.1:
@@ -2862,6 +2910,8 @@ snapshots:
       - '@types/react'
       - '@types/react-dom'
 
+  codepage@1.15.0: {}
+
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
@@ -2881,6 +2931,8 @@ snapshots:
       color-convert: 2.0.1
       color-string: 1.9.1
     optional: true
+
+  crc-32@1.2.2: {}
 
   csstype@3.1.3: {}
 
@@ -2961,6 +3013,8 @@ snapshots:
   eventemitter3@4.0.7: {}
 
   fast-equals@5.2.2: {}
+
+  frac@1.1.2: {}
 
   fraction.js@4.3.7: {}
 
@@ -3249,6 +3303,10 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
+  ssf@0.11.2:
+    dependencies:
+      frac: 1.1.2
+
   streamsearch@1.1.0: {}
 
   styled-jsx@5.1.6(react@19.0.0):
@@ -3335,6 +3393,20 @@ snapshots:
       d3-shape: 3.2.0
       d3-time: 3.1.0
       d3-timer: 3.0.1
+
+  wmf@1.0.2: {}
+
+  word@0.3.0: {}
+
+  xlsx@0.18.5:
+    dependencies:
+      adler-32: 1.3.1
+      cfb: 1.2.2
+      codepage: 1.15.0
+      crc-32: 1.2.2
+      ssf: 0.11.2
+      wmf: 1.0.2
+      word: 0.3.0
 
   yallist@5.0.0: {}
 

--- a/public/visor/index.html
+++ b/public/visor/index.html
@@ -474,6 +474,12 @@
       let currentPage = 1;
       let totalPages = 0;
 
+      function rememberPage() {
+        if (currentPdfName) {
+          localStorage.setItem('page:' + currentPdfName, String(currentPage));
+        }
+      }
+
       // Base size estimada (para skeletons)
       let baseWidth = 800;
       let baseHeight = 1100;
@@ -755,6 +761,7 @@
           pageWrapper.scrollIntoView({ behavior: 'instant', block: 'start' });
           currentPage = pageNum;
           showNavIndicator(`Página ${pageNum}/${totalPages}`);
+          rememberPage();
         }
       }
 
@@ -791,7 +798,12 @@
           buildPageSkeletons();
           prepareInitialReveal();
 
-          if (pendingAfterLoadGoTo === 'last') {
+          const saved = parseInt(
+            localStorage.getItem('page:' + filename) || '0',
+          );
+          if (saved > 0 && saved <= totalPages) {
+            setTimeout(() => scrollToPage(saved), 0);
+          } else if (pendingAfterLoadGoTo === 'last') {
             setTimeout(() => scrollToPage(totalPages), 0);
           } else {
             setTimeout(() => scrollToPage(1), 0);
@@ -1294,7 +1306,13 @@
         requestAnimationFrame(() => {
           currentPage = getCurrentPage();
           maybeReleaseFarPages();
+          rememberPage();
         });
+      });
+
+      container.addEventListener('scroll', () => {
+        currentPage = getCurrentPage();
+        rememberPage();
       });
 
       // ========================================
@@ -2084,6 +2102,14 @@
         await writable.close();
         const file = new File([blob], pdfName, { type: 'application/pdf' });
         return { handle: fileHandle, file, blob };
+      }
+
+      // cargar pdf inicial si viene por query
+      const params = new URLSearchParams(window.location.search);
+      const urlParam = params.get('url');
+      const nameParam = params.get('name');
+      if (urlParam && nameParam) {
+        loadPdf(urlParam, nameParam);
       }
 
       // ========================================


### PR DESCRIPTION
## Summary
- adapt gestor parsing to Semana/materia layout and allow tagging PDFs as theory or practice
- provide a cronograma panel with color-coded subjects and per-day filtering of pending PDFs
- open PDFs in a full-screen viewer that remembers last page and shows days remaining

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6899dccd494083309064ffd54ea758fa