### PR TITLE
feat: add full-screen viewer and schedule dashboard

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next'
 import { GeistSans } from 'geist/font/sans'
 import { GeistMono } from 'geist/font/mono'
 import './globals.css'
+import { ThemeProvider } from '@/components/theme-provider'
 
 export const metadata: Metadata = {
   title: 'v0 App',
@@ -15,7 +16,7 @@ export default function RootLayout({
   children: React.ReactNode
 }>) {
   return (
-    <html lang="en">
+    <html lang="es" suppressHydrationWarning>
       <head>
         <style>{`
 html {
@@ -25,7 +26,11 @@ html {
 }
         `}</style>
       </head>
-      <body>{children}</body>
+      <body>
+        <ThemeProvider attribute="class" defaultTheme="light" enableSystem>
+          {children}
+        </ThemeProvider>
+      </body>
     </html>
   )
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,359 +1,793 @@
 "use client"
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react"
-import { Button } from "@/components/ui/button"
-import { Card } from "@/components/ui/card"
-import { Separator } from "@/components/ui/separator"
-import { FolderOpen, Play, ArrowRight, ArrowLeft, Files, Info, RefreshCw } from 'lucide-react'
+import { useEffect, useState } from "react"
+import { useTheme } from "next-themes"
+import * as XLSX from "xlsx"
+import { PDFDocument } from "pdf-lib"
 
-// Tipos para manejar entradas de PDF de carpeta o como fallback (webkitdirectory)
-type PDFEntry = {
-  name: string
-  handle?: FileSystemFileHandle
-  file?: File
+const days = ["Lunes", "Martes", "Miércoles", "Jueves", "Viernes"]
+const dayMap: Record<string, number> = {
+  Lunes: 1,
+  Martes: 2,
+  Miércoles: 3,
+  Jueves: 4,
+  Viernes: 5,
 }
 
-// Natural sort por nombre de archivo para ordenar 01, 02, 10 correctamente
-function naturalCompare(a: string, b: string) {
-  return a.localeCompare(b, undefined, { numeric: true, sensitivity: "base" })
-}
-
-function isPDF(name: string) {
-  return name.toLowerCase().endsWith(".pdf")
+type PdfFile = {
+  file: File
+  path: string
+  week: number
+  subject: string
+  pages?: number
+  kind?: "teoria" | "practica" | null
 }
 
 export default function Home() {
-  const [entries, setEntries] = useState<PDFEntry[]>([])
-  const [currentIndex, setCurrentIndex] = useState<number | null>(null)
-  const [currentPage, setCurrentPage] = useState<number>(1)
-  const [totalPages, setTotalPages] = useState<number>(0)
-  const [loadingDoc, setLoadingDoc] = useState(false)
-  const [loadingPage, setLoadingPage] = useState(false)
-  const [error, setError] = useState<string | null>(null)
+  const { setTheme } = useTheme()
+  const [started, setStarted] = useState(false)
+  const [setupComplete, setSetupComplete] = useState(true)
+  const [step, setStep] = useState(1)
+  const [files, setFiles] = useState<File[]>([])
+  const [names, setNames] = useState<string[]>([])
+  const [theory, setTheory] = useState<Record<string, string>>({})
+  const [practice, setPractice] = useState<Record<string, string>>({})
+  const [folderReady, setFolderReady] = useState(false)
+  const [weeks, setWeeks] = useState(1)
+  const [dirFiles, setDirFiles] = useState<File[]>([])
+  const [fileTree, setFileTree] = useState<Record<number, Record<string, PdfFile[]>>>({})
+  const [completed, setCompleted] = useState<Record<string, boolean>>({})
+  const [pdfMeta, setPdfMeta] = useState<
+    Record<string, { kind?: "teoria" | "practica" | null; order: number; pages?: number }>
+  >({})
+  const [subjectColors, setSubjectColors] = useState<Record<string, string>>({})
+  const [currentPdf, setCurrentPdf] = useState<PdfFile | null>(null)
+  const [queue, setQueue] = useState<PdfFile[]>([])
+  const [queueIndex, setQueueIndex] = useState(0)
+  const [viewWeek, setViewWeek] = useState<number | null>(null)
+  const [viewSubject, setViewSubject] = useState<string | null>(null)
+  const [pdfUrl, setPdfUrl] = useState<string | null>(null)
+  const [showSchedule, setShowSchedule] = useState(false)
+  const [scheduleFilter, setScheduleFilter] = useState<string>("all")
+  const [selectedDay, setSelectedDay] = useState<string | null>(null)
 
-  // refs para PDF.js y canvas
-  const pdfLibRef = useRef<any>(null)
-  const pdfDocRef = useRef<any>(null)
-  const cancelRenderRef = useRef<(() => void) | null>(null)
-  const containerRef = useRef<HTMLDivElement | null>(null)
-  const canvasRef = useRef<HTMLCanvasElement | null>(null)
-  const inputDirRef = useRef<HTMLInputElement | null>(null)
-
-  // Preparar input webkitdirectory como alternativa si showDirectoryPicker no está disponible
+  // theme and setup flag
   useEffect(() => {
-    if (inputDirRef.current) {
-      // Algunos navegadores necesitan este atributo para permitir seleccionar carpetas
-      inputDirRef.current.setAttribute("webkitdirectory", "")
-      inputDirRef.current.setAttribute("directory", "")
+    const hour = new Date().getHours()
+    if (hour >= 19 || hour < 6) {
+      setTheme("dark")
+    } else {
+      setTheme("light")
     }
+    const stored = localStorage.getItem("setupComplete")
+    if (!stored) {
+      setSetupComplete(false)
+    } else {
+      const storedWeeks = parseInt(localStorage.getItem("weeks") || "1")
+      setWeeks(storedWeeks)
+    }
+  }, [setTheme])
+
+  // greeting handler
+  useEffect(() => {
+    const handler = () => setStarted(true)
+    if (!started) {
+      window.addEventListener("keydown", handler)
+      return () => window.removeEventListener("keydown", handler)
+    }
+  }, [started])
+
+  // load completed from storage
+  useEffect(() => {
+    const stored = localStorage.getItem("completed")
+    if (stored) setCompleted(JSON.parse(stored))
   }, [])
 
-  // Cargar PDF.js de forma dinámica para evitar problemas de worker y SSR
+  // persist completed
   useEffect(() => {
-    let mounted = true
-    const load = async () => {
-      try {
-        const pdfjsLib = await import("pdfjs-dist/build/pdf")
-        // Ajusta la versión si lo prefieres (probada)
-        pdfjsLib.GlobalWorkerOptions.workerSrc =
-          "https://unpkg.com/pdfjs-dist@2.16.105/build/pdf.worker.min.js"
-        if (mounted) {
-          pdfLibRef.current = pdfjsLib
+    localStorage.setItem("completed", JSON.stringify(completed))
+  }, [completed])
+
+  // load pdf meta
+  useEffect(() => {
+    const stored = localStorage.getItem("pdfMeta")
+    if (stored) setPdfMeta(JSON.parse(stored))
+  }, [])
+
+  // persist pdf meta
+  useEffect(() => {
+    localStorage.setItem("pdfMeta", JSON.stringify(pdfMeta))
+  }, [pdfMeta])
+
+  // build tree from selected directory
+  useEffect(() => {
+    const build = async () => {
+      const tree: Record<number, Record<string, PdfFile[]>> = {}
+      const meta = { ...pdfMeta }
+      let auto = 0
+      for (const file of dirFiles) {
+        const parts = (file as any).webkitRelativePath?.split("/") || []
+        if (parts.length >= 4) {
+          const weekPart = parts[1]
+          const subject = parts[2]
+          if (!file.name.toLowerCase().endsWith(".pdf")) continue
+          const week = parseInt(weekPart.replace(/\D/g, ""))
+          const path = parts.slice(1).join("/")
+          if (!tree[week]) tree[week] = {}
+          if (!tree[week][subject]) tree[week][subject] = []
+          const m = meta[path] || { order: auto++ }
+          if (m.pages === undefined) {
+            try {
+              const buf = await file.arrayBuffer()
+              const doc = await PDFDocument.load(buf)
+              m.pages = doc.getPageCount()
+            } catch {}
+          }
+          meta[path] = m
+          tree[week][subject].push({
+            file,
+            path,
+            week,
+            subject,
+            pages: m.pages,
+            kind: m.kind || null,
+          })
         }
-      } catch (e: any) {
-        console.error("Error cargando PDF.js:", e)
-        setError("No se pudo cargar el motor PDF")
       }
-    }
-    load()
-    return () => {
-      mounted = false
-    }
-  }, [])
-
-  // Orden visible de archivos
-  const orderedEntries = useMemo(() => {
-    return [...entries].sort((a, b) => naturalCompare(a.name, b.name))
-  }, [entries])
-
-  const currentFileName = useMemo(() => {
-    if (currentIndex == null) return null
-    return orderedEntries[currentIndex]?.name ?? null
-  }, [currentIndex, orderedEntries])
-
-  const resetViewer = useCallback(async () => {
-    // Cancelar render en curso
-    if (cancelRenderRef.current) {
-      try {
-        cancelRenderRef.current()
-      } catch {}
-      cancelRenderRef.current = null
-    }
-    // Destruir doc actual
-    if (pdfDocRef.current) {
-      try {
-        await pdfDocRef.current.destroy()
-      } catch {}
-      pdfDocRef.current = null
-    }
-    setTotalPages(0)
-    setCurrentPage(1)
-  }, [])
-
-  const pickFolder = useCallback(async () => {
-    setError(null)
-    setEntries([])
-    setCurrentIndex(null)
-    try {
-      // @ts-expect-error: showDirectoryPicker puede no existir en TS pero sí en runtime
-      if (!window.showDirectoryPicker) {
-        // Fallback: disparar input webkitdirectory
-        inputDirRef.current?.click()
-        return
+      for (const w in tree) {
+        for (const s in tree[w]) {
+          tree[w][s].sort(
+            (a, b) => (meta[a.path]?.order ?? 0) - (meta[b.path]?.order ?? 0),
+          )
+        }
       }
+      setPdfMeta(meta)
+      setFileTree(tree)
+    }
+    build()
+  }, [dirFiles])
 
-      const dirHandle: FileSystemDirectoryHandle = await (window as any).showDirectoryPicker({
-        mode: "read"
+  // update tree when metadata changes (order or labels)
+  useEffect(() => {
+    setFileTree((prev) => {
+      const copy: Record<number, Record<string, PdfFile[]>> = {}
+      for (const w in prev) {
+        copy[w] = {}
+        for (const s in prev[w]) {
+          copy[w][s] = [...prev[w][s]].sort(
+            (a, b) => (pdfMeta[a.path]?.order ?? 0) - (pdfMeta[b.path]?.order ?? 0),
+          )
+          copy[w][s].forEach((p) => {
+            p.kind = pdfMeta[p.path]?.kind || null
+            p.pages = pdfMeta[p.path]?.pages
+          })
+        }
+      }
+      return copy
+    })
+  }, [pdfMeta])
+
+  // compute queue ordered by urgency
+  useEffect(() => {
+    const today = new Date().getDay()
+    const stats: { subject: string; days: number; pdfs: PdfFile[] }[] = []
+    Object.values(fileTree).forEach((subjects) => {
+      Object.entries(subjects).forEach(([subject, files]) => {
+        const remaining = files.filter((f) => !completed[f.path])
+        if (!remaining.length) return
+        let days = 7
+        const t = theory[subject]
+        const p = practice[subject]
+        const candidates = [t, p]
+          .filter((d): d is string => !!d)
+          .map((d) => dayMap[d])
+        if (candidates.length) {
+          days = Math.min(
+            ...candidates.map((d) => {
+              let diff = d - today
+              if (diff < 0) diff += 7
+              if (diff === 0) diff = 7
+              return diff
+            }),
+          )
+        }
+        stats.push({ subject, days, pdfs: remaining })
       })
+    })
+    stats.sort((a, b) => {
+      if (a.days !== b.days) return a.days - b.days
+      return b.pdfs.length - a.pdfs.length
+    })
+    const q: PdfFile[] = []
+    stats.forEach((s) => {
+      q.push(
+        ...s.pdfs.sort((a, b) => a.week - b.week || a.file.name.localeCompare(b.file.name)),
+      )
+    })
+    setQueue(q)
+    if (q.length) {
+      const current = currentPdf && q.find((f) => f.path === currentPdf.path)
+      const target = current || q[0]
+      setCurrentPdf(target)
+      setQueueIndex(q.findIndex((f) => f.path === target.path))
+    } else {
+      setCurrentPdf(null)
+      setQueueIndex(0)
+    }
+  }, [fileTree, completed, theory, practice])
 
-      const found: PDFEntry[] = []
-      // Recorrer solo el primer nivel de la carpeta
-      // @ts-ignore: TypeScript no conoce correctamente entries() asíncrono
-      for await (const [name, handle] of (dirHandle as any).entries()) {
-        if (handle.kind === "file" && isPDF(name)) {
-          found.push({ name, handle })
+  // object url for viewer
+  useEffect(() => {
+    if (currentPdf) {
+      const url = URL.createObjectURL(currentPdf.file)
+      setPdfUrl(url)
+      return () => URL.revokeObjectURL(url)
+    }
+    setPdfUrl(null)
+  }, [currentPdf])
+
+  // greeting screen
+  if (!started) {
+    const hour = new Date().getHours()
+    const greeting = hour >= 19 || hour < 6 ? "Buenas noches" : "Buenos días"
+    return (
+      <main className="min-h-screen flex items-center justify-center text-2xl">
+        <p>{greeting}. Presiona cualquier tecla para continuar.</p>
+      </main>
+    )
+  }
+
+  // configuration wizard
+  if (!setupComplete) {
+    switch (step) {
+      case 1: {
+        const handleConfirm = async () => {
+          let maxWeek = 1
+          for (const file of files) {
+            const buffer = await file.arrayBuffer()
+            const wb = XLSX.read(buffer)
+            const sheet = wb.Sheets[wb.SheetNames[0]]
+            const rows = XLSX.utils.sheet_to_json<Record<string, any>>(sheet)
+            rows.forEach((r) => {
+              const w = parseInt(r["SEMANA"])
+              if (!isNaN(w) && w > maxWeek) maxWeek = w
+            })
+          }
+          setWeeks(maxWeek)
+          setNames(files.map(() => ""))
+          setStep(2)
         }
+        return (
+          <main className="min-h-screen flex flex-col items-center justify-center gap-4 p-4">
+            <h1 className="text-xl">Comencemos a configurar el entorno</h1>
+            <p>Paso 1: Sube tus cronogramas (excel)</p>
+            <input
+              type="file"
+              accept=".xlsx,.xls"
+              multiple
+              onChange={(e) => setFiles(Array.from(e.target.files || []))}
+            />
+            <button
+              className="px-4 py-2 border rounded"
+              disabled={!files.length}
+              onClick={handleConfirm}
+            >
+              Confirmar
+            </button>
+          </main>
+        )
       }
-
-      if (!found.length) {
-        setError("La carpeta no contiene archivos PDF.")
-        return
-      }
-
-      setEntries(found)
-    } catch (e: any) {
-      if (e?.name === "AbortError") return
-      console.error(e)
-      setError("No se pudo acceder a la carpeta.")
-    }
-  }, [])
-
-  const onFallbackFolder = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
-    setError(null)
-    const files = Array.from(e.target.files ?? []).filter((f) => isPDF(f.name))
-    if (!files.length) {
-      setError("La carpeta seleccionada no contiene PDFs.")
-      return
-    }
-    const list: PDFEntry[] = files.map((f) => ({ name: f.name, file: f }))
-    setEntries(list)
-  }, [])
-
-  // Cargar un PDF por índice
-  const loadPdfByIndex = useCallback(
-    async (index: number) => {
-      if (index < 0 || index >= orderedEntries.length) return
-      if (!pdfLibRef.current) {
-        setError("PDF.js aún no está listo.")
-        return
-      }
-      setLoadingDoc(true)
-      setError(null)
-      await resetViewer()
-
-      try {
-        const entry = orderedEntries[index]
-        let arrayBuffer: ArrayBuffer
-        if (entry.handle) {
-          const file = await entry.handle.getFile()
-          arrayBuffer = await file.arrayBuffer()
-        } else if (entry.file) {
-          arrayBuffer = await entry.file.arrayBuffer()
-        } else {
-          throw new Error("Entrada de PDF inválida.")
+      case 2: {
+        const updateName = (idx: number, value: string) => {
+          const next = [...names]
+          next[idx] = value
+          setNames(next)
         }
-
-        const loadingTask = pdfLibRef.current.getDocument({ data: arrayBuffer })
-        const pdf = await loadingTask.promise
-        pdfDocRef.current = pdf
-        setCurrentIndex(index)
-        setTotalPages(pdf.numPages)
-        setCurrentPage(1)
-      } catch (e: any) {
-        console.error("Error cargando PDF:", e)
-        setError("No se pudo abrir el PDF.")
-      } finally {
-        setLoadingDoc(false)
+        return (
+          <main className="min-h-screen flex flex-col items-center justify-center gap-4 p-4">
+            <p>Paso 2: Nombra tus cronogramas</p>
+            {files.map((f, i) => (
+              <label key={i} className="flex gap-2 items-center">
+                <span>{f.name} es de</span>
+                <input
+                  className="border p-1"
+                  value={names[i] || ""}
+                  onChange={(e) => updateName(i, e.target.value)}
+                />
+              </label>
+            ))}
+            <button
+              className="px-4 py-2 border rounded"
+              disabled={names.some((n) => !n)}
+              onClick={() => {
+                const palette = [
+                  "bg-red-500",
+                  "bg-green-500",
+                  "bg-blue-500",
+                  "bg-purple-500",
+                  "bg-pink-500",
+                  "bg-yellow-500",
+                ]
+                const colors: Record<string, string> = {}
+                names.forEach((n, i) => (colors[n] = palette[i % palette.length]))
+                setSubjectColors(colors)
+                setStep(3)
+              }}
+            >
+              Confirmar
+            </button>
+          </main>
+        )
       }
-    },
-    [orderedEntries, resetViewer]
-  )
-
-  // Renderizar una página actual cuando cambie el PDF, la página o el tamaño
-  const renderCurrentPage = useCallback(async () => {
-    if (!pdfDocRef.current || !canvasRef.current || !containerRef.current) return
-    if (!currentPage) return
-
-    setLoadingPage(true)
-    setError(null)
-
-    // Cancelación simple: cambiar flag local si llega una nueva renderización
-    let cancelled = false
-    cancelRenderRef.current = () => {
-      cancelled = true
-    }
-
-    try {
-      const page = await pdfDocRef.current.getPage(currentPage)
-      if (cancelled) return
-
-      const containerWidth = Math.max(320, containerRef.current.clientWidth)
-      const baseViewport = page.getViewport({ scale: 1 })
-      // Fit width
-      const scale = Math.max(0.5, Math.min(2.5, (containerWidth - 24) / baseViewport.width))
-      const viewport = page.getViewport({ scale })
-
-      const canvas = canvasRef.current
-      const ctx = canvas.getContext("2d")
-      if (!ctx) throw new Error("Canvas no disponible")
-
-      const ratio = window.devicePixelRatio || 1
-      canvas.width = Math.floor(viewport.width * ratio)
-      canvas.height = Math.floor(viewport.height * ratio)
-      canvas.style.width = `${viewport.width}px`
-      canvas.style.height = `${viewport.height}px`
-
-      ctx.setTransform(ratio, 0, 0, ratio, 0, 0)
-      const renderTask = page.render({
-        canvasContext: ctx,
-        viewport
-      })
-      await renderTask.promise
-
-      if (!cancelled) {
-        // ok
+      case 3: {
+        const unassigned = names.filter((n) => !theory[n])
+        const handleDrop = (subject: string, day: string) => {
+          setTheory({ ...theory, [subject]: day })
+        }
+        return (
+          <main className="min-h-screen flex flex-col items-center gap-4 p-4">
+            <p>Paso 3: Arrastra tus materias (teoría) a los días</p>
+            <div className="flex gap-4">
+              <div className="w-40 border p-2 min-h-40">
+                {unassigned.map((s) => (
+                  <div
+                    key={s}
+                    draggable
+                    onDragStart={(e) => e.dataTransfer.setData("text", s)}
+                    className="p-1 mb-2 bg-green-500 text-white cursor-move"
+                  >
+                    {s}
+                  </div>
+                ))}
+              </div>
+              {days.map((d) => (
+                <div
+                  key={d}
+                  onDragOver={(e) => e.preventDefault()}
+                  onDrop={(e) => handleDrop(e.dataTransfer.getData("text"), d)}
+                  className="border p-2 w-32 min-h-40"
+                >
+                  <div className="font-bold">{d}</div>
+                  {Object.entries(theory)
+                    .filter(([_, day]) => day === d)
+                    .map(([s]) => (
+                      <div key={s} className="p-1 mt-2 bg-green-200">
+                        {s}
+                      </div>
+                    ))}
+                </div>
+              ))}
+            </div>
+            {unassigned.length === 0 && (
+              <button
+                className="px-4 py-2 border rounded"
+                onClick={() => {
+                  setStep(4)
+                }}
+              >
+                Confirmar
+              </button>
+            )}
+          </main>
+        )
       }
-    } catch (e: any) {
-      if (!cancelled) {
-        console.error("Error renderizando página:", e)
-        setError("No se pudo renderizar la página.")
+      case 4: {
+        const unassigned = names.filter((n) => !practice[n])
+        const handleDrop = (subject: string, day: string) => {
+          setPractice({ ...practice, [subject]: day })
+        }
+        return (
+          <main className="min-h-screen flex flex-col items-center gap-4 p-4">
+            <p>Paso 3: Arrastra tus materias (práctica) a los días</p>
+            <div className="flex gap-4">
+              <div className="w-40 border p-2 min-h-40">
+                {unassigned.map((s) => (
+                  <div
+                    key={s}
+                    draggable
+                    onDragStart={(e) => e.dataTransfer.setData("text", s)}
+                    className="p-1 mb-2 bg-blue-500 text-white cursor-move"
+                  >
+                    {s}
+                  </div>
+                ))}
+              </div>
+              {days.map((d) => (
+                <div
+                  key={d}
+                  onDragOver={(e) => e.preventDefault()}
+                  onDrop={(e) => handleDrop(e.dataTransfer.getData("text"), d)}
+                  className="border p-2 w-32 min-h-40"
+                >
+                  <div className="font-bold">{d}</div>
+                  {Object.entries(practice)
+                    .filter(([_, day]) => day === d)
+                    .map(([s]) => (
+                      <div key={s} className="p-1 mt-2 bg-blue-200">
+                        {s}
+                      </div>
+                    ))}
+                </div>
+              ))}
+            </div>
+            {unassigned.length === 0 && (
+              <button
+                className="px-4 py-2 border rounded"
+                onClick={() => setStep(5)}
+              >
+                Confirmar
+              </button>
+            )}
+          </main>
+        )
       }
-    } finally {
-      if (!cancelled) setLoadingPage(false)
-    }
-  }, [currentPage])
-
-  // Re-render cuando cambien dependencias clave
-  useEffect(() => {
-    renderCurrentPage()
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [renderCurrentPage, totalPages, currentIndex])
-
-  // Re-render al redimensionar
-  useEffect(() => {
-    const onResize = () => {
-      renderCurrentPage()
-    }
-    window.addEventListener("resize", onResize)
-    return () => window.removeEventListener("resize", onResize)
-  }, [renderCurrentPage])
-
-  // Navegación entre páginas y PDFs
-  const canStart = entries.length > 0
-  const hasDoc = currentIndex != null && pdfDocRef.current
-  const canPrev =
-    hasDoc && (currentPage > 1 || (currentPage === 1 && (currentIndex ?? 0) > 0))
-  const canNext =
-    hasDoc &&
-    (currentPage < totalPages ||
-      (currentPage === totalPages && (currentIndex ?? 0) < orderedEntries.length - 1))
-
-  const goStart = useCallback(() => {
-    if (!canStart) return
-    loadPdfByIndex(0)
-  }, [canStart, loadPdfByIndex])
-
-  const goPrev = useCallback(async () => {
-    if (!hasDoc) return
-    // Si no estamos en la primera página, retroceder página
-    if (currentPage > 1) {
-      setCurrentPage((p) => p - 1)
-      return
-    }
-    // Si estamos en la primera página, ir al PDF anterior y saltar a su última página
-    const prevIndex = (currentIndex as number) - 1
-    if (prevIndex >= 0) {
-      await loadPdfByIndex(prevIndex)
-      // Esperar a que se ajuste totalPages
-      setTimeout(() => {
-        setCurrentPage((_) => (pdfDocRef.current ? pdfDocRef.current.numPages : 1))
-      }, 0)
-    }
-  }, [hasDoc, currentPage, currentIndex, loadPdfByIndex])
-
-  const goNext = useCallback(async () => {
-    if (!hasDoc) return
-    // Si no estamos en la última página, avanzar página
-    if (currentPage < totalPages) {
-      setCurrentPage((p) => p + 1)
-      return
-    }
-    // Si estamos en la última página, ir al siguiente PDF y saltar a su primera página
-    const nextIndex = (currentIndex as number) + 1
-    if (nextIndex < orderedEntries.length) {
-      await loadPdfByIndex(nextIndex)
-      // Primera página por defecto
-    }
-  }, [hasDoc, currentPage, totalPages, currentIndex, orderedEntries.length, loadPdfByIndex])
-
-  // Atajos de teclado: ← y → cruzan PDFs según el estado
-  useEffect(() => {
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "ArrowLeft") {
-        e.preventDefault()
-        if (canPrev) goPrev()
-      }
-      if (e.key === "ArrowRight") {
-        e.preventDefault()
-        if (canNext) goNext()
+      case 5: {
+        const finish = () => {
+          localStorage.setItem("setupComplete", "1")
+          localStorage.setItem("weeks", String(weeks))
+          setSetupComplete(true)
+          setStarted(false)
+        }
+        return (
+          <main className="min-h-screen flex flex-col items-center justify-center gap-4 p-4">
+            <p>Paso 4: Da acceso a la carpeta "gestor"</p>
+            <input
+              type="file"
+              // @ts-expect-error webkitdirectory es no estándar
+              webkitdirectory=""
+              onChange={(e) => {
+                setDirFiles(Array.from(e.target.files || []))
+                setFolderReady(true)
+              }}
+            />
+            <button
+              className="px-4 py-2 border rounded"
+              disabled={!folderReady}
+              onClick={finish}
+            >
+              Finalizar
+            </button>
+          </main>
+        )
       }
     }
-    window.addEventListener("keydown", onKey)
-    return () => window.removeEventListener("keydown", onKey)
-  }, [canPrev, canNext, goPrev, goNext])
+  }
 
-  const selectedCount = entries.length
-  const hintText =
-    "Usa ← y → para avanzar y retroceder. En la última página de un PDF saltas al siguiente; en la primera, al anterior."
+  const handleSelectPdf = (pdf: PdfFile) => {
+    const idx = queue.findIndex((f) => f.path === pdf.path)
+    if (idx >= 0) {
+      setQueueIndex(idx)
+      setCurrentPdf(queue[idx])
+    } else {
+      setCurrentPdf(pdf)
+    }
+  }
 
+  const prevPdf = () => {
+    if (queueIndex > 0) {
+      const i = queueIndex - 1
+      setQueueIndex(i)
+      setCurrentPdf(queue[i])
+    }
+  }
+
+  const nextPdf = () => {
+    if (queueIndex < queue.length - 1) {
+      const i = queueIndex + 1
+      setQueueIndex(i)
+      setCurrentPdf(queue[i])
+    }
+  }
+
+  const toggleComplete = () => {
+    if (!currentPdf) return
+    const key = currentPdf.path
+    setCompleted((prev) => ({ ...prev, [key]: !prev[key] }))
+  }
+
+  const updateKind = (path: string, kind: "teoria" | "practica") => {
+    setPdfMeta((prev) => ({
+      ...prev,
+      [path]: { ...(prev[path] || { order: Object.keys(prev).length }), kind },
+    }))
+  }
+
+  const movePdf = (week: number, subject: string, path: string, dir: number) => {
+    setPdfMeta((prev) => {
+      const next = { ...prev }
+      const files = fileTree[week]?.[subject] || []
+      const sorted = [...files].sort(
+        (a, b) => (prev[a.path]?.order ?? 0) - (prev[b.path]?.order ?? 0),
+      )
+      const idx = sorted.findIndex((p) => p.path === path)
+      const swap = sorted[idx + dir]
+      if (!swap) return prev
+      const curOrder = next[path]?.order ?? 0
+      const swapOrder = next[swap.path]?.order ?? 0
+      next[path] = { ...(next[path] || {}), order: swapOrder }
+      next[swap.path] = { ...(next[swap.path] || {}), order: curOrder }
+      return next
+    })
+  }
+
+  const computeRemaining = (pdf: PdfFile) => {
+    const meta = pdfMeta[pdf.path]
+    const schedule = meta?.kind === "practica" ? practice[pdf.subject] : theory[pdf.subject]
+    if (!schedule) return null
+    const today = new Date().getDay()
+    let diff = dayMap[schedule] - today
+    if (diff <= 0) diff += 7
+    return diff
+  }
+
+  // main interface
+  const remaining = currentPdf ? computeRemaining(currentPdf) : null
   return (
-    <main className="min-h-screen">
-      <iframe
-        title="Visor PDF avanzado"
-        src="/visor/index.html"
-        className="w-full h-screen border-0"
-      />
+    <main className="min-h-screen relative">
+      <div className="p-4">
+        <button
+          className="underline"
+          onClick={() => {
+            setShowSchedule((s) => !s)
+            setSelectedDay(null)
+          }}
+        >
+          {showSchedule ? "Ocultar cronograma" : "Ver cronograma"}
+        </button>
+        {showSchedule && (
+          <div className="mt-4 space-y-4">
+            <div>
+              <label className="mr-2">Materia:</label>
+              <select
+                className="border p-1"
+                value={scheduleFilter}
+                onChange={(e) => {
+                  setScheduleFilter(e.target.value)
+                  setSelectedDay(null)
+                }}
+              >
+                <option value="all">Todas</option>
+                {names.map((n) => (
+                  <option key={n} value={n}>
+                    {n}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className="flex gap-4">
+              {days.map((d) => (
+                <div
+                  key={d}
+                  className="flex-1 border p-2 cursor-pointer"
+                  onClick={() => setSelectedDay(d)}
+                >
+                  <div className="font-bold mb-2">{d}</div>
+                  <div className="flex flex-wrap gap-1">
+                    {names
+                      .filter((n) => scheduleFilter === "all" || scheduleFilter === n)
+                      .map((n) => {
+                        const isT = theory[n] === d
+                        const isP = practice[n] === d
+                        if (!isT && !isP) return null
+                        const color = subjectColors[n] || "bg-gray-400"
+                        const label = isT && isP ? "T/P" : isT ? "T" : "P"
+                        return (
+                          <div
+                            key={n}
+                            className={`w-6 h-6 rounded-full ${color} text-white text-xs flex items-center justify-center`}
+                            title={`${n} ${label}`}
+                          >
+                            {label[0]}
+                          </div>
+                        )
+                      })}
+                  </div>
+                </div>
+              ))}
+            </div>
+            {selectedDay && (
+              <div className="mt-2">
+                {(scheduleFilter === "all" ? names : [scheduleFilter]).map((subj) => {
+                  const list: PdfFile[] = []
+                  Object.values(fileTree).forEach((weeks) => {
+                    const files = weeks[subj] || []
+                    files.forEach((p) => {
+                      const meta = pdfMeta[p.path]
+                      const sched =
+                        (meta?.kind === "practica" ? practice[subj] : theory[subj]) || null
+                      if (sched === selectedDay && !completed[p.path]) {
+                        list.push(p)
+                      }
+                    })
+                  })
+                  if (!list.length) return null
+                  return (
+                    <div key={subj} className="mb-2">
+                      <div className="font-semibold">{subj}</div>
+                      <ul className="list-disc ml-4">
+                        {list.map((p) => (
+                          <li
+                            key={p.path}
+                            className="cursor-pointer underline"
+                            onClick={() => handleSelectPdf(p)}
+                          >
+                            {p.file.name}
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  )
+                })}
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+      <div className="grid grid-cols-2 min-h-screen">
+        <aside className="border-r p-4 space-y-2">
+          {!viewWeek && (
+            <>
+              <h2 className="text-xl">Semanas</h2>
+              <ul className="space-y-1">
+                {Array.from({ length: weeks }, (_, i) => {
+                  const wk = i + 1
+                  const locked = wk > 1
+                  return (
+                    <li key={wk} className={locked ? "opacity-50" : "font-bold"}>
+                      {locked ? (
+                        <>Semana {wk} 🔒</>
+                      ) : (
+                        <button onClick={() => setViewWeek(wk)}>Semana {wk}</button>
+                      )}
+                    </li>
+                  )
+                })}
+              </ul>
+            </>
+          )}
+          {viewWeek && !viewSubject && (
+            <>
+              <button className="mb-2 underline" onClick={() => setViewWeek(null)}>
+                ← Volver
+              </button>
+              <h2 className="text-xl">Semana {viewWeek}</h2>
+              <ul className="space-y-1">
+                {Object.keys(fileTree[viewWeek] || {}).map((s) => {
+                  const theoryFiles = (fileTree[viewWeek]?.[s] || []).filter(
+                    (p) => pdfMeta[p.path]?.kind === "teoria",
+                  )
+                  const total = theoryFiles.reduce(
+                    (sum, p) => sum + (pdfMeta[p.path]?.pages || 0),
+                    0,
+                  )
+                  const done = theoryFiles
+                    .filter((p) => completed[p.path])
+                    .reduce((sum, p) => sum + (pdfMeta[p.path]?.pages || 0), 0)
+                  const pct = total ? Math.round((done / total) * 100) : 0
+                  return (
+                    <li key={s} className="flex justify-between items-center">
+                      <button onClick={() => setViewSubject(s)}>{s}</button>
+                      <span className="text-sm text-gray-500">{pct}% teoría</span>
+                    </li>
+                  )
+                })}
+              </ul>
+            </>
+          )}
+          {viewWeek && viewSubject && (
+            <>
+              <button className="mb-2 underline" onClick={() => setViewSubject(null)}>
+                ← Volver
+              </button>
+              <h2 className="text-xl">{viewSubject}</h2>
+              <ul className="space-y-1">
+                {(fileTree[viewWeek]?.[viewSubject] || []).map((p) => (
+                  <li
+                    key={p.path}
+                    className={`flex items-center gap-2 ${
+                      completed[p.path] ? "line-through text-gray-400" : ""
+                    }`}
+                  >
+                    <span
+                      className="flex-1 cursor-pointer"
+                      onClick={() => handleSelectPdf(p)}
+                      title={p.file.name}
+                    >
+                      {p.file.name}
+                    </span>
+                    <select
+                      className="border text-xs"
+                      value={pdfMeta[p.path]?.kind || ""}
+                      onChange={(e) =>
+                        updateKind(
+                          p.path,
+                          e.target.value as "teoria" | "practica",
+                        )
+                      }
+                    >
+                      <option value="">-</option>
+                      <option value="teoria">T</option>
+                      <option value="practica">P</option>
+                    </select>
+                    <div className="flex flex-col">
+                      <button onClick={() => movePdf(p.week, p.subject, p.path, -1)}>
+                        ↑
+                      </button>
+                      <button onClick={() => movePdf(p.week, p.subject, p.path, 1)}>
+                        ↓
+                      </button>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            </>
+          )}
+        </aside>
+        <section className="p-4">
+          <h2 className="text-xl mb-2">Actual</h2>
+          {currentPdf ? (
+            <div className="flex items-center gap-2">
+              <span>📄</span>
+              <span className="truncate" title={currentPdf.file.name}>
+                {currentPdf.file.name}
+              </span>
+            </div>
+          ) : (
+            <p>Sin selección</p>
+          )}
+        </section>
+      </div>
+      {currentPdf && (
+        <div className="fixed inset-0 z-50 flex flex-col bg-white dark:bg-gray-900">
+          <div className="flex items-center justify-between p-2 border-b">
+            <div className="flex items-center gap-2">
+              <span>📄</span>
+              <span className="max-w-[50vw] truncate" title={currentPdf.file.name}>
+                {currentPdf.file.name}
+              </span>
+            </div>
+            <div className="flex items-center gap-2">
+              <button onClick={prevPdf} disabled={queueIndex <= 0}>
+                ←
+              </button>
+              <button onClick={nextPdf} disabled={queueIndex >= queue.length - 1}>
+                →
+              </button>
+              <input
+                type="checkbox"
+                checked={!!completed[currentPdf.path]}
+                onChange={toggleComplete}
+              />
+              <button onClick={() => setCurrentPdf(null)}>✕</button>
+            </div>
+          </div>
+          <iframe
+            title="Visor PDF avanzado"
+            src={
+              pdfUrl
+                ? `/visor/index.html?url=${encodeURIComponent(pdfUrl)}&name=${encodeURIComponent(
+                    currentPdf.file.name,
+                  )}`
+                : "/visor/index.html"
+            }
+            className="w-full flex-1 border-0"
+          />
+          {remaining !== null && (
+            <div
+              className={`p-2 text-center ${
+                remaining >= 3
+                  ? "text-green-500"
+                  : remaining === 2
+                  ? "text-yellow-500"
+                  : "text-red-500"
+              }`}
+            >
+              Días restantes: {remaining}
+            </div>
+          )}
+        </div>
+      )}
     </main>
   )
 }
 
-/**
- * Pequeño helper para disparar efectos imperativos cuando un "when" cambia,
- * sin forzar re-render del componente principal.
- */
-function RenderEffect({
-  when,
-  onEffect
-}: {
-  when: string | number | boolean
-  onEffect: () => void
-}) {
-  const prev = useRef<string | number | boolean | null>(null)
-  useEffect(() => {
-    if (prev.current !== when) {
-      prev.current = when
-      onEffect()
-    }
-  }, [when, onEffect])
-  return null
-}

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "lucide-react": "^0.454.0",
     "next": "15.2.4",
     "next-themes": "latest",
+    "pdf-lib": "1.17.1",
     "pdfjs-dist": "latest",
     "react": "^19",
     "react-day-picker": "9.8.0",
@@ -59,6 +60,7 @@
     "tailwind-merge": "^2.5.5",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^0.9.9",
+    "xlsx": "0.18.5",
     "zod": "3.25.67"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -125,6 +125,9 @@ importers:
       next-themes:
         specifier: latest
         version: 0.4.6(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      pdf-lib:
+        specifier: 1.17.1
+        version: 1.17.1
       pdfjs-dist:
         specifier: latest
         version: 5.4.54
@@ -158,6 +161,9 @@ importers:
       vaul:
         specifier: ^0.9.9
         version: 0.9.9(@types/react-dom@19.0.0)(@types/react@19.0.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      xlsx:
+        specifier: 0.18.5
+        version: 0.18.5
       zod:
         specifier: 3.25.67
         version: 3.25.67
@@ -463,6 +469,12 @@ packages:
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
+
+  '@pdf-lib/standard-fonts@1.0.0':
+    resolution: {integrity: sha512-hU30BK9IUN/su0Mn9VdlVKsWBS6GyhVfqjwl1FjZN4TxP6cCw0jP2w7V3Hf5uX7M0AZJ16vey9yE0ny7Sa59ZA==}
+
+  '@pdf-lib/upng@1.0.1':
+    resolution: {integrity: sha512-dQK2FUMQtowVP00mtIksrlZhdFXQZPC+taih1q4CvPZ5vqdxR/LKBaFg0oAfzd1GlHZXXSPdQfzQnt+ViGvEIQ==}
 
   '@radix-ui/number@1.1.0':
     resolution: {integrity: sha512-V3gRzhVNU1ldS5XhAPTom1fOIo4ccrjjJgmE+LI2h/WaFpHmx0MQApT+KZHnx8abG6Avtfcz4WoEciMnpFT3HQ==}
@@ -1250,6 +1262,10 @@ packages:
   '@types/react@19.0.0':
     resolution: {integrity: sha512-MY3oPudxvMYyesqs/kW1Bh8y9VqSmf+tzqw3ae8a9DZW68pUe3zAdHeI1jc6iAysuRdACnVknHP8AhwD4/dxtg==}
 
+  adler-32@1.3.1:
+    resolution: {integrity: sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==}
+    engines: {node: '>=0.8'}
+
   aria-hidden@1.2.6:
     resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
     engines: {node: '>=10'}
@@ -1273,6 +1289,10 @@ packages:
   caniuse-lite@1.0.30001733:
     resolution: {integrity: sha512-e4QKw/O2Kavj2VQTKZWrwzkt3IxOmIlU6ajRb6LP64LHpBo1J67k2Hi4Vu/TgJWsNtynurfS0uK3MaUTCPfu5Q==}
 
+  cfb@1.2.2:
+    resolution: {integrity: sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==}
+    engines: {node: '>=0.8'}
+
   chownr@3.0.0:
     resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
     engines: {node: '>=18'}
@@ -1293,6 +1313,10 @@ packages:
       react: ^18 || ^19 || ^19.0.0-rc
       react-dom: ^18 || ^19 || ^19.0.0-rc
 
+  codepage@1.15.0:
+    resolution: {integrity: sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==}
+    engines: {node: '>=0.8'}
+
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
@@ -1306,6 +1330,11 @@ packages:
   color@4.2.3:
     resolution: {integrity: sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==}
     engines: {node: '>=12.5.0'}
+
+  crc-32@1.2.2:
+    resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
+    engines: {node: '>=0.8'}
+    hasBin: true
 
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
@@ -1403,6 +1432,10 @@ packages:
   fast-equals@5.2.2:
     resolution: {integrity: sha512-V7/RktU11J3I36Nwq2JnZEM7tNm17eBJz+u25qdxBZeCKiX6BkVSZQjwWIr+IobgnZy+ag73tTZgZi7tr0LrBw==}
     engines: {node: '>=6.0.0'}
+
+  frac@1.1.2:
+    resolution: {integrity: sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==}
+    engines: {node: '>=0.8'}
 
   fraction.js@4.3.7:
     resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}
@@ -1574,6 +1607,12 @@ packages:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
 
+  pako@1.0.11:
+    resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
+
+  pdf-lib@1.17.1:
+    resolution: {integrity: sha512-V/mpyJAoTsN4cnP31vc0wfNA1+p20evqqnap0KLoRUN0Yk/p3wN52DOEsL4oBFcLdb76hlpKPtzJIgo67j/XLw==}
+
   pdfjs-dist@5.4.54:
     resolution: {integrity: sha512-TBAiTfQw89gU/Z4LW98Vahzd2/LoCFprVGvGbTgFt+QCB1F+woyOPmNNVgLa6djX9Z9GGTnj7qE1UzpOVJiINw==}
     engines: {node: '>=20.16.0 || >=22.3.0'}
@@ -1705,6 +1744,10 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
+  ssf@0.11.2:
+    resolution: {integrity: sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==}
+    engines: {node: '>=0.8'}
+
   streamsearch@1.1.0:
     resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
     engines: {node: '>=10.0.0'}
@@ -1743,6 +1786,9 @@ packages:
 
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
+
+  tslib@1.14.1:
+    resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -1797,6 +1843,19 @@ packages:
 
   victory-vendor@36.9.2:
     resolution: {integrity: sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==}
+
+  wmf@1.0.2:
+    resolution: {integrity: sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==}
+    engines: {node: '>=0.8'}
+
+  word@0.3.0:
+    resolution: {integrity: sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==}
+    engines: {node: '>=0.8'}
+
+  xlsx@0.18.5:
+    resolution: {integrity: sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==}
+    engines: {node: '>=0.8'}
+    hasBin: true
 
   yallist@5.0.0:
     resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
@@ -2006,6 +2065,14 @@ snapshots:
 
   '@next/swc-win32-x64-msvc@15.2.4':
     optional: true
+
+  '@pdf-lib/standard-fonts@1.0.0':
+    dependencies:
+      pako: 1.0.11
+
+  '@pdf-lib/upng@1.0.1':
+    dependencies:
+      pako: 1.0.11
 
   '@radix-ui/number@1.1.0': {}
 
@@ -2813,6 +2880,8 @@ snapshots:
     dependencies:
       csstype: 3.1.3
 
+  adler-32@1.3.1: {}
+
   aria-hidden@1.2.6:
     dependencies:
       tslib: 2.8.1
@@ -2840,6 +2909,11 @@ snapshots:
 
   caniuse-lite@1.0.30001733: {}
 
+  cfb@1.2.2:
+    dependencies:
+      adler-32: 1.3.1
+      crc-32: 1.2.2
+
   chownr@3.0.0: {}
 
   class-variance-authority@0.7.1:
@@ -2862,6 +2936,8 @@ snapshots:
       - '@types/react'
       - '@types/react-dom'
 
+  codepage@1.15.0: {}
+
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
@@ -2881,6 +2957,8 @@ snapshots:
       color-convert: 2.0.1
       color-string: 1.9.1
     optional: true
+
+  crc-32@1.2.2: {}
 
   csstype@3.1.3: {}
 
@@ -2961,6 +3039,8 @@ snapshots:
   eventemitter3@4.0.7: {}
 
   fast-equals@5.2.2: {}
+
+  frac@1.1.2: {}
 
   fraction.js@4.3.7: {}
 
@@ -3090,6 +3170,15 @@ snapshots:
   normalize-range@0.1.2: {}
 
   object-assign@4.1.1: {}
+
+  pako@1.0.11: {}
+
+  pdf-lib@1.17.1:
+    dependencies:
+      '@pdf-lib/standard-fonts': 1.0.0
+      '@pdf-lib/upng': 1.0.1
+      pako: 1.0.11
+      tslib: 1.14.1
 
   pdfjs-dist@5.4.54:
     optionalDependencies:
@@ -3249,6 +3338,10 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
+  ssf@0.11.2:
+    dependencies:
+      frac: 1.1.2
+
   streamsearch@1.1.0: {}
 
   styled-jsx@5.1.6(react@19.0.0):
@@ -3276,6 +3369,8 @@ snapshots:
       yallist: 5.0.0
 
   tiny-invariant@1.3.3: {}
+
+  tslib@1.14.1: {}
 
   tslib@2.8.1: {}
 
@@ -3335,6 +3430,20 @@ snapshots:
       d3-shape: 3.2.0
       d3-time: 3.1.0
       d3-timer: 3.0.1
+
+  wmf@1.0.2: {}
+
+  word@0.3.0: {}
+
+  xlsx@0.18.5:
+    dependencies:
+      adler-32: 1.3.1
+      cfb: 1.2.2
+      codepage: 1.15.0
+      crc-32: 1.2.2
+      ssf: 0.11.2
+      wmf: 1.0.2
+      word: 0.3.0
 
   yallist@5.0.0: {}
 

--- a/public/visor/index.html
+++ b/public/visor/index.html
@@ -758,6 +758,15 @@
         }
       }
 
+      container.addEventListener('scroll', () => {
+        if (!currentPdfName) return;
+        const p = getCurrentPage();
+        if (p !== currentPage) {
+          currentPage = p;
+          try { localStorage.setItem('pdfPage:' + currentPdfName, String(p)); } catch {}
+        }
+      });
+
       // ========================================
       // CARGA DE PDF
       // ========================================
@@ -778,7 +787,8 @@
           const loadingTask = pdfjsLib.getDocument(url);
           pdfDoc = await loadingTask.promise;
           totalPages = pdfDoc.numPages;
-          currentPage = 1;
+          const saved = parseInt(localStorage.getItem('pdfPage:' + filename) || '1');
+          currentPage = isNaN(saved) ? 1 : Math.min(Math.max(saved, 1), totalPages);
 
           // Tamaño base
           try {
@@ -791,11 +801,10 @@
           buildPageSkeletons();
           prepareInitialReveal();
 
-          if (pendingAfterLoadGoTo === 'last') {
-            setTimeout(() => scrollToPage(totalPages), 0);
-          } else {
-            setTimeout(() => scrollToPage(1), 0);
-          }
+          let initial = currentPage;
+          if (pendingAfterLoadGoTo === 'last') initial = totalPages;
+          else if (pendingAfterLoadGoTo === 'first') initial = 1;
+          setTimeout(() => scrollToPage(initial), 0);
           pendingAfterLoadGoTo = null;
 
           if (directoryHandle) {
@@ -2084,6 +2093,14 @@
         await writable.close();
         const file = new File([blob], pdfName, { type: 'application/pdf' });
         return { handle: fileHandle, file, blob };
+      }
+
+      // cargar pdf inicial si viene por query
+      const params = new URLSearchParams(window.location.search);
+      const urlParam = params.get('url');
+      const nameParam = params.get('name');
+      if (urlParam && nameParam) {
+        loadPdf(urlParam, nameParam);
       }
 
       // ========================================


### PR DESCRIPTION
## Summary
- parse gestor files using Semana N/Materia hierarchy and track per-PDF metadata like pages, type and custom order
- add schedule dashboard with colored subject tokens, day filters and per-week theory progress
- show PDFs in a full-screen viewer overlay with completion control, queue navigation, days remaining and remembered page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6899dccd494083309064ffd54ea758fa