### PR TITLE
feat: load PDFs from gestor and save study artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# user configuration
+gestor/system/notas/config.json

--- a/app/api/capture/route.ts
+++ b/app/api/capture/route.ts
@@ -1,0 +1,19 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { promises as fs } from 'fs'
+import path from 'path'
+import { readConfig } from '@/lib/config'
+
+export async function POST(req: NextRequest) {
+  const form = await req.formData()
+  const file = form.get('file') as File | null
+  const category = form.get('category') as string | null
+  if (!file || !category) return NextResponse.json({ error: 'bad request' }, { status: 400 })
+  const data = Buffer.from(await file.arrayBuffer())
+  const cfg = await readConfig()
+  const base = cfg.basePath || path.join(process.cwd(), 'gestor')
+  const dir = path.join(base, 'system', `capturas-${category}`)
+  await fs.mkdir(dir, { recursive: true })
+  const filePath = path.join(dir, file.name)
+  await fs.writeFile(filePath, data)
+  return NextResponse.json({ ok: true })
+}

--- a/app/api/config/route.ts
+++ b/app/api/config/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from 'next/server'
+import { readConfig, writeConfig } from '@/lib/config'
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url)
+  const base = searchParams.get('base') || undefined
+  const cfg = await readConfig(base)
+  return NextResponse.json(cfg)
+}
+
+export async function POST(req: Request) {
+  const data = await req
+    .json()
+    .catch(() => ({}))
+  const ok = await writeConfig(data)
+  return NextResponse.json({ ok }, { status: ok ? 200 : 500 })
+}

--- a/app/api/files/route.ts
+++ b/app/api/files/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from 'next/server'
+import { promises as fs } from 'fs'
+import path from 'path'
+import { PDFDocument } from 'pdf-lib'
+import { readConfig } from '@/lib/config'
+
+export async function GET() {
+  const cfg = await readConfig()
+  const base = cfg.basePath || path.join(process.cwd(), 'gestor')
+  const result: Record<number, Record<string, { path: string; name: string; pages: number }[]>> = {}
+  try {
+    const subjects = await fs.readdir(base)
+    for (const subject of subjects) {
+      const subjPath = path.join(base, subject)
+      const stat = await fs.stat(subjPath)
+      if (!stat.isDirectory()) continue
+      const weeks = await fs.readdir(subjPath)
+      for (const weekFolder of weeks) {
+        const match = weekFolder.match(/sem(\d+)/i)
+        if (!match) continue
+        const week = parseInt(match[1])
+        const weekPath = path.join(subjPath, weekFolder)
+        const files = await fs.readdir(weekPath)
+        for (const file of files) {
+          if (!file.toLowerCase().endsWith('.pdf')) continue
+          const abs = path.join(weekPath, file)
+          let pages = 0
+          try {
+            const data = await fs.readFile(abs)
+            const pdf = await PDFDocument.load(data)
+            pages = pdf.getPageCount()
+          } catch {}
+          if (!result[week]) result[week] = {}
+          if (!result[week][subject]) result[week][subject] = []
+          result[week][subject].push({
+            path: path.relative(base, abs),
+            name: file,
+            pages,
+          })
+        }
+      }
+    }
+  } catch {}
+  return NextResponse.json(result)
+}

--- a/app/api/note/route.ts
+++ b/app/api/note/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { promises as fs } from 'fs'
+import path from 'path'
+import { readConfig } from '@/lib/config'
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url)
+  const name = searchParams.get('name')
+  if (!name) return NextResponse.json({ error: 'name required' }, { status: 400 })
+  const cfg = await readConfig()
+  const base = cfg.basePath || path.join(process.cwd(), 'gestor')
+  const file = path.join(base, 'system', 'notas', name)
+  try {
+    const data = await fs.readFile(file, 'utf-8')
+    return NextResponse.json(JSON.parse(data))
+  } catch {
+    return NextResponse.json({})
+  }
+}
+
+export async function POST(req: NextRequest) {
+  const body = await req.json()
+  const { name, data } = body
+  if (!name) return NextResponse.json({ error: 'name required' }, { status: 400 })
+  const cfg = await readConfig()
+  const base = cfg.basePath || path.join(process.cwd(), 'gestor')
+  const dir = path.join(base, 'system', 'notas')
+  await fs.mkdir(dir, { recursive: true })
+  const file = path.join(dir, name)
+  await fs.writeFile(file, JSON.stringify(data, null, 2), 'utf-8')
+  return NextResponse.json({ ok: true })
+}

--- a/app/api/pdf/route.ts
+++ b/app/api/pdf/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { promises as fs } from 'fs'
+import path from 'path'
+import { readConfig } from '@/lib/config'
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url)
+  const filePath = searchParams.get('path')
+  if (!filePath) return NextResponse.json({ error: 'path required' }, { status: 400 })
+  const cfg = await readConfig()
+  const base = cfg.basePath || path.join(process.cwd(), 'gestor')
+  const abs = path.join(base, filePath)
+  try {
+    const data = await fs.readFile(abs)
+    return new NextResponse(data, {
+      headers: { 'Content-Type': 'application/pdf' },
+    })
+  } catch {
+    return NextResponse.json({ error: 'not found' }, { status: 404 })
+  }
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next'
 import { GeistSans } from 'geist/font/sans'
 import { GeistMono } from 'geist/font/mono'
 import './globals.css'
+import { ThemeProvider } from '@/components/theme-provider'
 
 export const metadata: Metadata = {
   title: 'v0 App',
@@ -15,7 +16,7 @@ export default function RootLayout({
   children: React.ReactNode
 }>) {
   return (
-    <html lang="en">
+    <html lang="es" suppressHydrationWarning>
       <head>
         <style>{`
 html {
@@ -25,7 +26,11 @@ html {
 }
         `}</style>
       </head>
-      <body>{children}</body>
+      <body>
+        <ThemeProvider attribute="class" defaultTheme="light" enableSystem>
+          {children}
+        </ThemeProvider>
+      </body>
     </html>
   )
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,359 +1,949 @@
 "use client"
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react"
-import { Button } from "@/components/ui/button"
-import { Card } from "@/components/ui/card"
-import { Separator } from "@/components/ui/separator"
-import { FolderOpen, Play, ArrowRight, ArrowLeft, Files, Info, RefreshCw } from 'lucide-react'
+import { useEffect, useState, useRef } from "react"
+import { useTheme } from "next-themes"
+import * as XLSX from "xlsx"
 
-// Tipos para manejar entradas de PDF de carpeta o como fallback (webkitdirectory)
-type PDFEntry = {
+const days = ["Lunes", "Martes", "Miércoles", "Jueves", "Viernes"]
+const dayMap: Record<string, number> = {
+  Lunes: 1,
+  Martes: 2,
+  Miércoles: 3,
+  Jueves: 4,
+  Viernes: 5,
+}
+
+type PdfFile = {
+  path: string
   name: string
-  handle?: FileSystemFileHandle
-  file?: File
-}
-
-// Natural sort por nombre de archivo para ordenar 01, 02, 10 correctamente
-function naturalCompare(a: string, b: string) {
-  return a.localeCompare(b, undefined, { numeric: true, sensitivity: "base" })
-}
-
-function isPDF(name: string) {
-  return name.toLowerCase().endsWith(".pdf")
+  week: number
+  subject: string
+  pages?: number
+  kind?: "teoria" | "practica" | null
 }
 
 export default function Home() {
-  const [entries, setEntries] = useState<PDFEntry[]>([])
-  const [currentIndex, setCurrentIndex] = useState<number | null>(null)
-  const [currentPage, setCurrentPage] = useState<number>(1)
-  const [totalPages, setTotalPages] = useState<number>(0)
-  const [loadingDoc, setLoadingDoc] = useState(false)
-  const [loadingPage, setLoadingPage] = useState(false)
-  const [error, setError] = useState<string | null>(null)
+  const { setTheme } = useTheme()
+  const [started, setStarted] = useState(false)
+  const [setupComplete, setSetupComplete] = useState(true)
+  const [step, setStep] = useState(0)
+  const [basePath, setBasePath] = useState('')
+  const [files, setFiles] = useState<File[]>([])
+  const [names, setNames] = useState<string[]>([])
+  const [theory, setTheory] = useState<Record<string, string>>({})
+  const [practice, setPractice] = useState<Record<string, string>>({})
+  const [weeks, setWeeks] = useState(1)
+  const [fileTree, setFileTree] = useState<Record<number, Record<string, PdfFile[]>>>({})
+  const [completed, setCompleted] = useState<Record<string, boolean>>({})
+  const [pdfMeta, setPdfMeta] = useState<
+    Record<
+      string,
+      { kind?: "teoria" | "practica" | null; order: number; pages?: number; lastPage?: number }
+    >
+  >({})
+  const [subjectColors, setSubjectColors] = useState<Record<string, string>>({})
+  const [currentPdf, setCurrentPdf] = useState<PdfFile | null>(null)
+  const [queue, setQueue] = useState<PdfFile[]>([])
+  const [queueIndex, setQueueIndex] = useState(0)
+  const [viewWeek, setViewWeek] = useState<number | null>(null)
+  const [viewSubject, setViewSubject] = useState<string | null>(null)
+  const [showSchedule, setShowSchedule] = useState(false)
+  const [scheduleFilter, setScheduleFilter] = useState<string>("all")
+  const [selectedDay, setSelectedDay] = useState<string | null>(null)
+  const [lastOpened, setLastOpened] = useState<string | null>(null)
+  const colorPickers = useRef<Record<string, HTMLInputElement | null>>({})
 
-  // refs para PDF.js y canvas
-  const pdfLibRef = useRef<any>(null)
-  const pdfDocRef = useRef<any>(null)
-  const cancelRenderRef = useRef<(() => void) | null>(null)
-  const containerRef = useRef<HTMLDivElement | null>(null)
-  const canvasRef = useRef<HTMLCanvasElement | null>(null)
-  const inputDirRef = useRef<HTMLInputElement | null>(null)
-
-  // Preparar input webkitdirectory como alternativa si showDirectoryPicker no está disponible
+  // theme and basic stored data
   useEffect(() => {
-    if (inputDirRef.current) {
-      // Algunos navegadores necesitan este atributo para permitir seleccionar carpetas
-      inputDirRef.current.setAttribute("webkitdirectory", "")
-      inputDirRef.current.setAttribute("directory", "")
+    const hour = new Date().getHours()
+    setTheme(hour >= 19 || hour < 6 ? 'dark' : 'light')
+    const storedBase = localStorage.getItem('basePath')
+    if (storedBase) {
+      setBasePath(storedBase)
+    } else {
+      setSetupComplete(false)
+      setStep(0)
     }
+    const storedNames = localStorage.getItem('names')
+    if (storedNames) setNames(JSON.parse(storedNames))
+    const storedWeeks = parseInt(localStorage.getItem('weeks') || '1')
+    setWeeks(storedWeeks)
+    const vw = localStorage.getItem('viewWeek')
+    if (vw) setViewWeek(parseInt(vw))
+    const vs = localStorage.getItem('viewSubject')
+    if (vs) setViewSubject(vs)
+    if (localStorage.getItem('started')) setStarted(true)
+  }, [setTheme])
+
+  // greeting handler
+  useEffect(() => {
+    const handler = () => {
+      setStarted(true)
+      localStorage.setItem("started", "1")
+    }
+    if (!started) {
+      window.addEventListener("keydown", handler)
+      return () => window.removeEventListener("keydown", handler)
+    }
+  }, [started])
+
+  // load completed from storage
+  useEffect(() => {
+    const stored = localStorage.getItem("completed")
+    if (stored) setCompleted(JSON.parse(stored))
   }, [])
 
-  // Cargar PDF.js de forma dinámica para evitar problemas de worker y SSR
+  // persist completed
   useEffect(() => {
-    let mounted = true
+    localStorage.setItem("completed", JSON.stringify(completed))
+  }, [completed])
+
+  // load pdf meta
+  useEffect(() => {
+    const stored = localStorage.getItem("pdfMeta")
+    if (stored) setPdfMeta(JSON.parse(stored))
+  }, [])
+
+  // persist pdf meta
+  useEffect(() => {
+    localStorage.setItem("pdfMeta", JSON.stringify(pdfMeta))
+  }, [pdfMeta])
+
+  // load additional settings once base path is known
+  useEffect(() => {
+    if (!basePath) return
+    const s = localStorage.getItem('subjectColors')
+    if (s) setSubjectColors(JSON.parse(s))
+    const t = localStorage.getItem('theory')
+    if (t) setTheory(JSON.parse(t))
+    const p = localStorage.getItem('practice')
+    if (p) setPractice(JSON.parse(p))
+    const lo = localStorage.getItem('lastOpened')
+    if (lo) setLastOpened(lo)
+    fetch(`/api/config?base=${encodeURIComponent(basePath)}`)
+      .then((r) => r.json())
+      .then((cfg) => {
+        if (cfg.subjectColors) setSubjectColors(cfg.subjectColors)
+        if (cfg.theory) setTheory(cfg.theory)
+        if (cfg.practice) setPractice(cfg.practice)
+        if (cfg.pdfMeta) setPdfMeta(cfg.pdfMeta)
+        if (cfg.completed) setCompleted(cfg.completed)
+        if (cfg.lastOpened) setLastOpened(cfg.lastOpened)
+        if (cfg.names) setNames(cfg.names)
+        if (cfg.weeks) setWeeks(cfg.weeks)
+        if (cfg.setupComplete !== undefined) setSetupComplete(cfg.setupComplete)
+        if (cfg.viewWeek !== undefined) setViewWeek(cfg.viewWeek)
+        if (cfg.viewSubject !== undefined) setViewSubject(cfg.viewSubject)
+      })
+      .catch(() => {})
+  }, [basePath])
+
+  useEffect(() => {
+    localStorage.setItem("subjectColors", JSON.stringify(subjectColors))
+  }, [subjectColors])
+  useEffect(() => {
+    localStorage.setItem("theory", JSON.stringify(theory))
+  }, [theory])
+  useEffect(() => {
+    localStorage.setItem("practice", JSON.stringify(practice))
+  }, [practice])
+  useEffect(() => {
+    if (lastOpened) localStorage.setItem("lastOpened", lastOpened)
+  }, [lastOpened])
+  useEffect(() => {
+    localStorage.setItem("names", JSON.stringify(names))
+  }, [names])
+
+  useEffect(() => {
+    if (basePath) localStorage.setItem('basePath', basePath)
+  }, [basePath])
+
+  useEffect(() => {
+    if (viewWeek !== null) localStorage.setItem("viewWeek", String(viewWeek))
+  }, [viewWeek])
+
+  useEffect(() => {
+    if (viewSubject) localStorage.setItem("viewSubject", viewSubject)
+    else localStorage.removeItem("viewSubject")
+  }, [viewSubject])
+  
+  useEffect(() => {
+    if (!basePath) return
+    const body = {
+      basePath,
+      pdfMeta,
+      completed,
+      subjectColors,
+      theory,
+      practice,
+      lastOpened,
+      names,
+      weeks,
+      setupComplete,
+      viewWeek,
+      viewSubject,
+    }
+    const payload = JSON.stringify(body)
+    try {
+      navigator.sendBeacon('/api/config', payload)
+    } catch {
+      fetch('/api/config', { method: 'POST', body: payload })
+    }
+  }, [
+    basePath,
+    pdfMeta,
+    completed,
+    subjectColors,
+    theory,
+    practice,
+    lastOpened,
+    names,
+    weeks,
+    setupComplete,
+    viewWeek,
+    viewSubject,
+  ])
+
+  // load file tree from server
+  useEffect(() => {
+    if (!setupComplete || !basePath) return
     const load = async () => {
-      try {
-        const pdfjsLib = await import("pdfjs-dist/build/pdf")
-        // Ajusta la versión si lo prefieres (probada)
-        pdfjsLib.GlobalWorkerOptions.workerSrc =
-          "https://unpkg.com/pdfjs-dist@2.16.105/build/pdf.worker.min.js"
-        if (mounted) {
-          pdfLibRef.current = pdfjsLib
+      const res = await fetch("/api/files")
+      const data: Record<number, Record<string, { path: string; name: string; pages: number }[]>> = await res.json()
+      const tree: Record<number, Record<string, PdfFile[]>> = {}
+      const meta = { ...pdfMeta }
+      let auto = 0
+      for (const w in data) {
+        const week = Number(w)
+        tree[week] = {}
+        for (const s in data[w]) {
+          if (!names.includes(s)) continue
+          tree[week][s] = data[w][s].map((p) => {
+            const m = meta[p.path] || { order: auto++ }
+            m.pages = p.pages
+            meta[p.path] = m
+            return { path: p.path, name: p.name, week, subject: s, pages: p.pages, kind: m.kind || null }
+          }).sort((a, b) => (meta[a.path]?.order ?? 0) - (meta[b.path]?.order ?? 0))
         }
-      } catch (e: any) {
-        console.error("Error cargando PDF.js:", e)
-        setError("No se pudo cargar el motor PDF")
       }
+      setPdfMeta(meta)
+      setFileTree(tree)
     }
     load()
-    return () => {
-      mounted = false
-    }
-  }, [])
+  }, [setupComplete, names, basePath])
 
-  // Orden visible de archivos
-  const orderedEntries = useMemo(() => {
-    return [...entries].sort((a, b) => naturalCompare(a.name, b.name))
-  }, [entries])
-
-  const currentFileName = useMemo(() => {
-    if (currentIndex == null) return null
-    return orderedEntries[currentIndex]?.name ?? null
-  }, [currentIndex, orderedEntries])
-
-  const resetViewer = useCallback(async () => {
-    // Cancelar render en curso
-    if (cancelRenderRef.current) {
-      try {
-        cancelRenderRef.current()
-      } catch {}
-      cancelRenderRef.current = null
-    }
-    // Destruir doc actual
-    if (pdfDocRef.current) {
-      try {
-        await pdfDocRef.current.destroy()
-      } catch {}
-      pdfDocRef.current = null
-    }
-    setTotalPages(0)
-    setCurrentPage(1)
-  }, [])
-
-  const pickFolder = useCallback(async () => {
-    setError(null)
-    setEntries([])
-    setCurrentIndex(null)
-    try {
-      // @ts-expect-error: showDirectoryPicker puede no existir en TS pero sí en runtime
-      if (!window.showDirectoryPicker) {
-        // Fallback: disparar input webkitdirectory
-        inputDirRef.current?.click()
-        return
-      }
-
-      const dirHandle: FileSystemDirectoryHandle = await (window as any).showDirectoryPicker({
-        mode: "read"
-      })
-
-      const found: PDFEntry[] = []
-      // Recorrer solo el primer nivel de la carpeta
-      // @ts-ignore: TypeScript no conoce correctamente entries() asíncrono
-      for await (const [name, handle] of (dirHandle as any).entries()) {
-        if (handle.kind === "file" && isPDF(name)) {
-          found.push({ name, handle })
+  // update tree when metadata changes (order or labels)
+  useEffect(() => {
+    setFileTree((prev) => {
+      const copy: Record<number, Record<string, PdfFile[]>> = {}
+      for (const w in prev) {
+        copy[w] = {}
+        for (const s in prev[w]) {
+          copy[w][s] = [...prev[w][s]].sort(
+            (a, b) => (pdfMeta[a.path]?.order ?? 0) - (pdfMeta[b.path]?.order ?? 0),
+          )
+          copy[w][s].forEach((p) => {
+            p.kind = pdfMeta[p.path]?.kind || null
+            p.pages = pdfMeta[p.path]?.pages
+          })
         }
       }
+      return copy
+    })
+  }, [pdfMeta])
 
-      if (!found.length) {
-        setError("La carpeta no contiene archivos PDF.")
-        return
-      }
-
-      setEntries(found)
-    } catch (e: any) {
-      if (e?.name === "AbortError") return
-      console.error(e)
-      setError("No se pudo acceder a la carpeta.")
-    }
-  }, [])
-
-  const onFallbackFolder = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
-    setError(null)
-    const files = Array.from(e.target.files ?? []).filter((f) => isPDF(f.name))
-    if (!files.length) {
-      setError("La carpeta seleccionada no contiene PDFs.")
-      return
-    }
-    const list: PDFEntry[] = files.map((f) => ({ name: f.name, file: f }))
-    setEntries(list)
-  }, [])
-
-  // Cargar un PDF por índice
-  const loadPdfByIndex = useCallback(
-    async (index: number) => {
-      if (index < 0 || index >= orderedEntries.length) return
-      if (!pdfLibRef.current) {
-        setError("PDF.js aún no está listo.")
-        return
-      }
-      setLoadingDoc(true)
-      setError(null)
-      await resetViewer()
-
-      try {
-        const entry = orderedEntries[index]
-        let arrayBuffer: ArrayBuffer
-        if (entry.handle) {
-          const file = await entry.handle.getFile()
-          arrayBuffer = await file.arrayBuffer()
-        } else if (entry.file) {
-          arrayBuffer = await entry.file.arrayBuffer()
-        } else {
-          throw new Error("Entrada de PDF inválida.")
+  // compute queue ordered by urgency
+  useEffect(() => {
+    const today = new Date().getDay()
+    const stats: { subject: string; days: number; pdfs: PdfFile[] }[] = []
+    Object.values(fileTree).forEach((subjects) => {
+      Object.entries(subjects).forEach(([subject, files]) => {
+        const remaining = files.filter((f) => !completed[f.path])
+        if (!remaining.length) return
+        let days = 7
+        const t = theory[subject]
+        const p = practice[subject]
+        const candidates = [t, p]
+          .filter((d): d is string => !!d)
+          .map((d) => dayMap[d])
+        if (candidates.length) {
+          days = Math.min(
+            ...candidates.map((d) => {
+              let diff = d - today
+              if (diff < 0) diff += 7
+              if (diff === 0) diff = 7
+              return diff
+            }),
+          )
         }
-
-        const loadingTask = pdfLibRef.current.getDocument({ data: arrayBuffer })
-        const pdf = await loadingTask.promise
-        pdfDocRef.current = pdf
-        setCurrentIndex(index)
-        setTotalPages(pdf.numPages)
-        setCurrentPage(1)
-      } catch (e: any) {
-        console.error("Error cargando PDF:", e)
-        setError("No se pudo abrir el PDF.")
-      } finally {
-        setLoadingDoc(false)
-      }
-    },
-    [orderedEntries, resetViewer]
-  )
-
-  // Renderizar una página actual cuando cambie el PDF, la página o el tamaño
-  const renderCurrentPage = useCallback(async () => {
-    if (!pdfDocRef.current || !canvasRef.current || !containerRef.current) return
-    if (!currentPage) return
-
-    setLoadingPage(true)
-    setError(null)
-
-    // Cancelación simple: cambiar flag local si llega una nueva renderización
-    let cancelled = false
-    cancelRenderRef.current = () => {
-      cancelled = true
-    }
-
-    try {
-      const page = await pdfDocRef.current.getPage(currentPage)
-      if (cancelled) return
-
-      const containerWidth = Math.max(320, containerRef.current.clientWidth)
-      const baseViewport = page.getViewport({ scale: 1 })
-      // Fit width
-      const scale = Math.max(0.5, Math.min(2.5, (containerWidth - 24) / baseViewport.width))
-      const viewport = page.getViewport({ scale })
-
-      const canvas = canvasRef.current
-      const ctx = canvas.getContext("2d")
-      if (!ctx) throw new Error("Canvas no disponible")
-
-      const ratio = window.devicePixelRatio || 1
-      canvas.width = Math.floor(viewport.width * ratio)
-      canvas.height = Math.floor(viewport.height * ratio)
-      canvas.style.width = `${viewport.width}px`
-      canvas.style.height = `${viewport.height}px`
-
-      ctx.setTransform(ratio, 0, 0, ratio, 0, 0)
-      const renderTask = page.render({
-        canvasContext: ctx,
-        viewport
+        stats.push({ subject, days, pdfs: remaining })
       })
-      await renderTask.promise
+    })
+    stats.sort((a, b) => {
+      if (a.days !== b.days) return a.days - b.days
+      return b.pdfs.length - a.pdfs.length
+    })
+    const q: PdfFile[] = []
+    stats.forEach((s) => {
+      q.push(
+        ...s.pdfs.sort((a, b) => a.week - b.week || a.name.localeCompare(b.name)),
+      )
+    })
+    setQueue(q)
+    if (q.length) {
+      const current = currentPdf && q.find((f) => f.path === currentPdf.path)
+      const last = lastOpened ? q.find((f) => f.path === lastOpened) : null
+      const target = current || last || q[0]
+      setCurrentPdf(target)
+      setQueueIndex(q.findIndex((f) => f.path === target.path))
+    } else {
+      setCurrentPdf(null)
+      setQueueIndex(0)
+    }
+  }, [fileTree, completed, theory, practice, lastOpened])
 
-      if (!cancelled) {
-        // ok
+  // greeting screen
+  if (!started) {
+    const hour = new Date().getHours()
+    const greeting = hour >= 19 || hour < 6 ? "Buenas noches" : "Buenos días"
+    return (
+      <main className="min-h-screen flex items-center justify-center text-2xl">
+        <p>{greeting}. Presiona cualquier tecla para continuar.</p>
+      </main>
+    )
+  }
+
+  // configuration wizard
+  if (!setupComplete) {
+    switch (step) {
+      case 0: {
+        const handleConfirm = async () => {
+          if (!basePath) return
+          localStorage.setItem('basePath', basePath)
+          const cfg = await fetch(`/api/config?base=${encodeURIComponent(basePath)}`)
+            .then((r) => r.json())
+            .catch(() => ({}))
+          if (cfg.subjectColors) setSubjectColors(cfg.subjectColors)
+          if (cfg.theory) setTheory(cfg.theory)
+          if (cfg.practice) setPractice(cfg.practice)
+          if (cfg.pdfMeta) setPdfMeta(cfg.pdfMeta)
+          if (cfg.completed) setCompleted(cfg.completed)
+          if (cfg.lastOpened) setLastOpened(cfg.lastOpened)
+          if (cfg.names) setNames(cfg.names)
+          if (cfg.weeks) setWeeks(cfg.weeks)
+          if (cfg.viewWeek !== undefined) setViewWeek(cfg.viewWeek)
+          if (cfg.viewSubject !== undefined) setViewSubject(cfg.viewSubject)
+          const done = cfg.setupComplete
+          setSetupComplete(!!done)
+          if (!done) setStep(1)
+        }
+        return (
+          <main className="min-h-screen flex flex-col items-center justify-center gap-4 p-4">
+            <h1 className="text-xl">Comencemos a configurar el entorno</h1>
+            <p>Paso 0: Indica la ruta de tu carpeta gestor</p>
+            <input
+              className="border p-1 w-80"
+              value={basePath}
+              onChange={(e) => setBasePath(e.target.value)}
+            />
+            <button
+              className="px-4 py-2 border rounded"
+              disabled={!basePath}
+              onClick={handleConfirm}
+            >
+              Confirmar
+            </button>
+          </main>
+        )
       }
-    } catch (e: any) {
-      if (!cancelled) {
-        console.error("Error renderizando página:", e)
-        setError("No se pudo renderizar la página.")
+      case 1: {
+        const handleConfirm = async () => {
+          let maxWeek = 1
+          for (const file of files) {
+            const buffer = await file.arrayBuffer()
+            const wb = XLSX.read(buffer)
+            const sheet = wb.Sheets[wb.SheetNames[0]]
+            const rows = XLSX.utils.sheet_to_json<Record<string, any>>(sheet)
+            rows.forEach((r) => {
+              const w = parseInt(r["SEMANA"])
+              if (!isNaN(w) && w > maxWeek) maxWeek = w
+            })
+          }
+          setWeeks(maxWeek)
+          setNames(files.map(() => ""))
+          setStep(2)
+        }
+        return (
+          <main className="min-h-screen flex flex-col items-center justify-center gap-4 p-4">
+            <h1 className="text-xl">Comencemos a configurar el entorno</h1>
+            <p>Paso 1: Sube tus cronogramas (excel)</p>
+            <input
+              type="file"
+              accept=".xlsx,.xls"
+              multiple
+              onChange={(e) => setFiles(Array.from(e.target.files || []))}
+            />
+            <button
+              className="px-4 py-2 border rounded"
+              disabled={!files.length}
+              onClick={handleConfirm}
+            >
+              Confirmar
+            </button>
+          </main>
+        )
       }
-    } finally {
-      if (!cancelled) setLoadingPage(false)
-    }
-  }, [currentPage])
-
-  // Re-render cuando cambien dependencias clave
-  useEffect(() => {
-    renderCurrentPage()
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [renderCurrentPage, totalPages, currentIndex])
-
-  // Re-render al redimensionar
-  useEffect(() => {
-    const onResize = () => {
-      renderCurrentPage()
-    }
-    window.addEventListener("resize", onResize)
-    return () => window.removeEventListener("resize", onResize)
-  }, [renderCurrentPage])
-
-  // Navegación entre páginas y PDFs
-  const canStart = entries.length > 0
-  const hasDoc = currentIndex != null && pdfDocRef.current
-  const canPrev =
-    hasDoc && (currentPage > 1 || (currentPage === 1 && (currentIndex ?? 0) > 0))
-  const canNext =
-    hasDoc &&
-    (currentPage < totalPages ||
-      (currentPage === totalPages && (currentIndex ?? 0) < orderedEntries.length - 1))
-
-  const goStart = useCallback(() => {
-    if (!canStart) return
-    loadPdfByIndex(0)
-  }, [canStart, loadPdfByIndex])
-
-  const goPrev = useCallback(async () => {
-    if (!hasDoc) return
-    // Si no estamos en la primera página, retroceder página
-    if (currentPage > 1) {
-      setCurrentPage((p) => p - 1)
-      return
-    }
-    // Si estamos en la primera página, ir al PDF anterior y saltar a su última página
-    const prevIndex = (currentIndex as number) - 1
-    if (prevIndex >= 0) {
-      await loadPdfByIndex(prevIndex)
-      // Esperar a que se ajuste totalPages
-      setTimeout(() => {
-        setCurrentPage((_) => (pdfDocRef.current ? pdfDocRef.current.numPages : 1))
-      }, 0)
-    }
-  }, [hasDoc, currentPage, currentIndex, loadPdfByIndex])
-
-  const goNext = useCallback(async () => {
-    if (!hasDoc) return
-    // Si no estamos en la última página, avanzar página
-    if (currentPage < totalPages) {
-      setCurrentPage((p) => p + 1)
-      return
-    }
-    // Si estamos en la última página, ir al siguiente PDF y saltar a su primera página
-    const nextIndex = (currentIndex as number) + 1
-    if (nextIndex < orderedEntries.length) {
-      await loadPdfByIndex(nextIndex)
-      // Primera página por defecto
-    }
-  }, [hasDoc, currentPage, totalPages, currentIndex, orderedEntries.length, loadPdfByIndex])
-
-  // Atajos de teclado: ← y → cruzan PDFs según el estado
-  useEffect(() => {
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "ArrowLeft") {
-        e.preventDefault()
-        if (canPrev) goPrev()
+      case 2: {
+        const updateName = (idx: number, value: string) => {
+          const next = [...names]
+          next[idx] = value
+          setNames(next)
+        }
+        return (
+          <main className="min-h-screen flex flex-col items-center justify-center gap-4 p-4">
+            <p>Paso 2: Nombra tus cronogramas</p>
+            {files.map((f, i) => (
+              <label key={i} className="flex gap-2 items-center">
+                <span>{f.name} es de</span>
+                <input
+                  className="border p-1"
+                  value={names[i] || ""}
+                  onChange={(e) => updateName(i, e.target.value)}
+                />
+              </label>
+            ))}
+            <button
+              className="px-4 py-2 border rounded"
+              disabled={names.some((n) => !n)}
+              onClick={() => {
+                const palette = [
+                  "bg-red-500",
+                  "bg-green-500",
+                  "bg-blue-500",
+                  "bg-purple-500",
+                  "bg-pink-500",
+                  "bg-yellow-500",
+                ]
+                const colors: Record<string, string> = {}
+                names.forEach((n, i) => (colors[n] = palette[i % palette.length]))
+                setSubjectColors(colors)
+                setStep(3)
+              }}
+            >
+              Confirmar
+            </button>
+          </main>
+        )
       }
-      if (e.key === "ArrowRight") {
-        e.preventDefault()
-        if (canNext) goNext()
+      case 3: {
+        const unassigned = names.filter((n) => !theory[n])
+        const handleDrop = (subject: string, day: string) => {
+          setTheory({ ...theory, [subject]: day })
+        }
+        return (
+          <main className="min-h-screen flex flex-col items-center gap-4 p-4">
+            <p>Paso 3: Arrastra tus materias (teoría) a los días</p>
+            <div className="flex gap-4">
+              <div className="w-40 border p-2 min-h-40">
+                {unassigned.map((s) => (
+                  <div
+                    key={s}
+                    draggable
+                    onDragStart={(e) => e.dataTransfer.setData("text", s)}
+                    className="p-1 mb-2 bg-green-500 text-white cursor-move"
+                  >
+                    {s}
+                  </div>
+                ))}
+              </div>
+              {days.map((d) => (
+                <div
+                  key={d}
+                  onDragOver={(e) => e.preventDefault()}
+                  onDrop={(e) => handleDrop(e.dataTransfer.getData("text"), d)}
+                  className="border p-2 w-32 min-h-40"
+                >
+                  <div className="font-bold">{d}</div>
+                  {Object.entries(theory)
+                    .filter(([_, day]) => day === d)
+                    .map(([s]) => (
+                      <div key={s} className="p-1 mt-2 bg-green-200">
+                        {s}
+                      </div>
+                    ))}
+                </div>
+              ))}
+            </div>
+            {unassigned.length === 0 && (
+              <button
+                className="px-4 py-2 border rounded"
+                onClick={() => {
+                  setStep(4)
+                }}
+              >
+                Confirmar
+              </button>
+            )}
+          </main>
+        )
+      }
+      case 4: {
+        const unassigned = names.filter((n) => !practice[n])
+        const handleDrop = (subject: string, day: string) => {
+          setPractice({ ...practice, [subject]: day })
+        }
+        return (
+          <main className="min-h-screen flex flex-col items-center gap-4 p-4">
+            <p>Paso 3: Arrastra tus materias (práctica) a los días</p>
+            <div className="flex gap-4">
+              <div className="w-40 border p-2 min-h-40">
+                {unassigned.map((s) => (
+                  <div
+                    key={s}
+                    draggable
+                    onDragStart={(e) => e.dataTransfer.setData("text", s)}
+                    className="p-1 mb-2 bg-blue-500 text-white cursor-move"
+                  >
+                    {s}
+                  </div>
+                ))}
+              </div>
+              {days.map((d) => (
+                <div
+                  key={d}
+                  onDragOver={(e) => e.preventDefault()}
+                  onDrop={(e) => handleDrop(e.dataTransfer.getData("text"), d)}
+                  className="border p-2 w-32 min-h-40"
+                >
+                  <div className="font-bold">{d}</div>
+                  {Object.entries(practice)
+                    .filter(([_, day]) => day === d)
+                    .map(([s]) => (
+                      <div key={s} className="p-1 mt-2 bg-blue-200">
+                        {s}
+                      </div>
+                    ))}
+                </div>
+              ))}
+            </div>
+            {unassigned.length === 0 && (
+              <button
+                className="px-4 py-2 border rounded"
+                onClick={() => setStep(5)}
+              >
+                Confirmar
+              </button>
+            )}
+          </main>
+        )
+      }
+      case 5: {
+        const finish = () => {
+          localStorage.setItem("setupComplete", "1")
+          localStorage.setItem("weeks", String(weeks))
+          setSetupComplete(true)
+          setStarted(false)
+          localStorage.removeItem("started")
+        }
+        return (
+          <main className="min-h-screen flex flex-col items-center justify-center gap-4 p-4">
+            <p>Paso 4: Da acceso a la carpeta "gestor"</p>
+            <p>Se utilizará la carpeta preconfigurada.</p>
+            <button className="px-4 py-2 border rounded" onClick={finish}>
+              Finalizar
+            </button>
+          </main>
+        )
       }
     }
-    window.addEventListener("keydown", onKey)
-    return () => window.removeEventListener("keydown", onKey)
-  }, [canPrev, canNext, goPrev, goNext])
+  }
 
-  const selectedCount = entries.length
-  const hintText =
-    "Usa ← y → para avanzar y retroceder. En la última página de un PDF saltas al siguiente; en la primera, al anterior."
+  const handleSelectPdf = (pdf: PdfFile) => {
+    const idx = queue.findIndex((f) => f.path === pdf.path)
+    if (idx >= 0) {
+      setQueueIndex(idx)
+      setCurrentPdf(queue[idx])
+    } else {
+      setCurrentPdf(pdf)
+    }
+    setLastOpened(pdf.path)
+  }
 
+  const prevPdf = () => {
+    if (queueIndex > 0) {
+      const i = queueIndex - 1
+      setQueueIndex(i)
+      setCurrentPdf(queue[i])
+      setLastOpened(queue[i].path)
+    }
+  }
+
+  const nextPdf = () => {
+    if (queueIndex < queue.length - 1) {
+      const i = queueIndex + 1
+      setQueueIndex(i)
+      setCurrentPdf(queue[i])
+      setLastOpened(queue[i].path)
+    }
+  }
+
+  const toggleComplete = () => {
+    if (!currentPdf) return
+    const key = currentPdf.path
+    setCompleted((prev) => ({ ...prev, [key]: !prev[key] }))
+  }
+
+  const updateKind = (path: string, kind: "teoria" | "practica") => {
+    setPdfMeta((prev) => ({
+      ...prev,
+      [path]: { ...(prev[path] || { order: Object.keys(prev).length }), kind },
+    }))
+  }
+
+  const movePdf = (week: number, subject: string, path: string, dir: number) => {
+    setPdfMeta((prev) => {
+      const next = { ...prev }
+      const files = fileTree[week]?.[subject] || []
+      const sorted = [...files].sort(
+        (a, b) => (prev[a.path]?.order ?? 0) - (prev[b.path]?.order ?? 0),
+      )
+      const idx = sorted.findIndex((p) => p.path === path)
+      const swap = sorted[idx + dir]
+      if (!swap) return prev
+      const curOrder = next[path]?.order ?? 0
+      const swapOrder = next[swap.path]?.order ?? 0
+      next[path] = { ...(next[path] || {}), order: swapOrder }
+      next[swap.path] = { ...(next[swap.path] || {}), order: curOrder }
+      return next
+    })
+  }
+
+  const openFull = () => {
+    if (!currentPdf) return
+    const page = pdfMeta[currentPdf.path]?.lastPage || 1
+    const params = new URLSearchParams({
+      path: currentPdf.path,
+      name: currentPdf.name,
+      page: String(page),
+    })
+    const body = JSON.stringify({
+      basePath,
+      pdfMeta,
+      completed,
+      subjectColors,
+      theory,
+      practice,
+      lastOpened: currentPdf.path,
+      names,
+      weeks,
+      setupComplete,
+      viewWeek,
+      viewSubject,
+    })
+    try {
+      navigator.sendBeacon('/api/config', body)
+    } catch {
+      fetch('/api/config', { method: 'POST', body })
+    }
+    window.location.href = `/visor/index.html?${params.toString()}`
+  }
+
+  const computeRemaining = (pdf: PdfFile) => {
+    const meta = pdfMeta[pdf.path]
+    const schedule = meta?.kind === "practica" ? practice[pdf.subject] : theory[pdf.subject]
+    if (!schedule) return null
+    const today = new Date().getDay()
+    let diff = dayMap[schedule] - today
+    if (diff <= 0) diff += 7
+    return diff
+  }
+
+  // main interface
+  const remaining = currentPdf ? computeRemaining(currentPdf) : null
   return (
-    <main className="min-h-screen">
-      <iframe
-        title="Visor PDF avanzado"
-        src="/visor/index.html"
-        className="w-full h-screen border-0"
-      />
+    <main className="min-h-screen relative">
+      <div className="p-4">
+        <button
+          className="underline"
+          onClick={() => {
+            setShowSchedule((s) => !s)
+            setSelectedDay(null)
+          }}
+        >
+          {showSchedule ? "Ocultar cronograma" : "Ver cronograma"}
+        </button>
+        {showSchedule && (
+          <div className="mt-4 space-y-4">
+            <div className="flex gap-2 items-center">
+              <div key="all">
+                <button
+                  className={`w-6 h-6 rounded-full border ${
+                    scheduleFilter === 'all' ? 'ring-2 ring-black' : ''
+                  }`}
+                  style={{ backgroundColor: '#9ca3af' }}
+                  onClick={() => {
+                    setScheduleFilter('all')
+                    setSelectedDay(null)
+                  }}
+                />
+              </div>
+              {names.map((n) => (
+                <div key={n} className="relative">
+                  <button
+                    className={`w-6 h-6 rounded-full border ${
+                      scheduleFilter === n ? "ring-2 ring-black" : ""
+                    }`}
+                    style={{ backgroundColor: subjectColors[n] || "#9ca3af" }}
+                    onClick={() => {
+                      setScheduleFilter(scheduleFilter === n ? "all" : n)
+                      setSelectedDay(null)
+                    }}
+                    onContextMenu={(e) => {
+                      e.preventDefault()
+                      colorPickers.current[n]?.click()
+                    }}
+                  />
+                  <input
+                    type="color"
+                    ref={(el) => (colorPickers.current[n] = el)}
+                    className="hidden"
+                    value={subjectColors[n] || "#9ca3af"}
+                    onChange={(e) =>
+                      setSubjectColors((prev) => ({ ...prev, [n]: e.target.value }))
+                    }
+                  />
+                </div>
+              ))}
+            </div>
+            <div className="flex gap-4">
+              {days.map((d) => (
+                <div
+                  key={d}
+                  className="flex-1 border p-2 cursor-pointer"
+                  onClick={() => setSelectedDay(d)}
+                >
+                  <div className="font-bold mb-2">{d}</div>
+                  <div className="flex flex-wrap gap-1">
+                    {names
+                      .filter((n) => scheduleFilter === "all" || scheduleFilter === n)
+                      .map((n) => {
+                        const isT = theory[n] === d
+                        const isP = practice[n] === d
+                        if (!isT && !isP) return null
+                        const color = subjectColors[n] || "#9ca3af"
+                        const label = isT && isP ? "T/P" : isT ? "T" : "P"
+                        return (
+                          <div
+                            key={n}
+                            className="w-6 h-6 rounded-full text-white text-xs flex items-center justify-center"
+                            style={{ backgroundColor: color }}
+                            title={`${n} ${label}`}
+                          >
+                            {label[0]}
+                          </div>
+                        )
+                      })}
+                  </div>
+                </div>
+              ))}
+            </div>
+            {selectedDay && (
+              <div className="mt-2">
+                {(scheduleFilter === "all" ? names : [scheduleFilter]).map((subj) => {
+                  const list: PdfFile[] = []
+                  Object.values(fileTree).forEach((weeks) => {
+                    const files = weeks[subj] || []
+                    files.forEach((p) => {
+                      const meta = pdfMeta[p.path]
+                      const sched =
+                        (meta?.kind === "practica" ? practice[subj] : theory[subj]) || null
+                      if (sched === selectedDay && !completed[p.path]) {
+                        list.push(p)
+                      }
+                    })
+                  })
+                  if (!list.length) return null
+                  return (
+                    <div key={subj} className="mb-2">
+                      <div className="font-semibold">{subj}</div>
+                      <ul className="list-disc ml-4">
+                        {list.map((p) => (
+                          <li
+                            key={p.path}
+                            className="cursor-pointer underline"
+                            onClick={() => handleSelectPdf(p)}
+                          >
+                            {p.name}
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  )
+                })}
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+      <div className="grid grid-cols-2 min-h-screen">
+        <aside className="border-r p-4 space-y-2">
+          {!viewWeek && (
+            <>
+              <h2 className="text-xl">Semanas</h2>
+              <ul className="space-y-1">
+                {Array.from({ length: weeks }, (_, i) => {
+                  const wk = i + 1
+                  const locked = wk > 1
+                  return (
+                    <li key={wk} className={locked ? "opacity-50" : "font-bold"}>
+                      {locked ? (
+                        <>Semana {wk} 🔒</>
+                      ) : (
+                        <button onClick={() => setViewWeek(wk)}>Semana {wk}</button>
+                      )}
+                    </li>
+                  )
+                })}
+              </ul>
+            </>
+          )}
+          {viewWeek && !viewSubject && (
+            <>
+              <button className="mb-2 underline" onClick={() => setViewWeek(null)}>
+                ← Volver
+              </button>
+              <h2 className="text-xl">Semana {viewWeek}</h2>
+              <ul className="space-y-1">
+                {Object.keys(fileTree[viewWeek] || {}).map((s) => {
+                  const theoryFiles = (fileTree[viewWeek]?.[s] || []).filter(
+                    (p) => pdfMeta[p.path]?.kind === "teoria",
+                  )
+                  const total = theoryFiles.reduce(
+                    (sum, p) => sum + (pdfMeta[p.path]?.pages || 0),
+                    0,
+                  )
+                  const done = theoryFiles
+                    .filter((p) => completed[p.path])
+                    .reduce((sum, p) => sum + (pdfMeta[p.path]?.pages || 0), 0)
+                  const pct = total ? Math.round((done / total) * 100) : 0
+                  return (
+                    <li key={s} className="flex justify-between items-center">
+                      <button onClick={() => setViewSubject(s)}>{s}</button>
+                      <span className="text-sm text-gray-500">{pct}% teoría</span>
+                    </li>
+                  )
+                })}
+              </ul>
+            </>
+          )}
+          {viewWeek && viewSubject && (
+            <>
+              <button className="mb-2 underline" onClick={() => setViewSubject(null)}>
+                ← Volver
+              </button>
+              <h2 className="text-xl">{viewSubject}</h2>
+              <ul className="space-y-1">
+                {(fileTree[viewWeek]?.[viewSubject] || []).map((p) => (
+                  <li
+                    key={p.path}
+                    className={`flex items-center gap-2 ${
+                      completed[p.path] ? "line-through text-gray-400" : ""
+                    }`}
+                  >
+                    <span
+                      className="flex-1 cursor-pointer"
+                      onClick={() => handleSelectPdf(p)}
+                      title={p.name}
+                    >
+                      {p.name}
+                    </span>
+                    <select
+                      className="border text-xs"
+                      value={pdfMeta[p.path]?.kind || ""}
+                      onClick={(e) => e.stopPropagation()}
+                      onChange={(e) =>
+                        updateKind(
+                          p.path,
+                          e.target.value as "teoria" | "practica",
+                        )
+                      }
+                    >
+                      <option value="">-</option>
+                      <option value="teoria">T</option>
+                      <option value="practica">P</option>
+                    </select>
+                    <div className="flex flex-col">
+                      <button
+                        onClick={(e) => {
+                          e.stopPropagation()
+                          movePdf(p.week, p.subject, p.path, -1)
+                        }}
+                      >
+                        ↑
+                      </button>
+                      <button
+                        onClick={(e) => {
+                          e.stopPropagation()
+                          movePdf(p.week, p.subject, p.path, 1)
+                        }}
+                      >
+                        ↓
+                      </button>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            </>
+          )}
+        </aside>
+        <section className="p-4 flex flex-col">
+          <h2 className="text-xl mb-2">Actual</h2>
+          {currentPdf ? (
+            <>
+              <div className="flex items-center gap-2 mb-2">
+                <button onClick={prevPdf} disabled={queueIndex <= 0}>←</button>
+                <button onClick={nextPdf} disabled={queueIndex >= queue.length - 1}>→</button>
+                <span>📄</span>
+                <span className="truncate flex-1" title={currentPdf.name}>
+                  {currentPdf.name}
+                </span>
+                <input
+                  type="checkbox"
+                  checked={!!completed[currentPdf.path]}
+                  onChange={toggleComplete}
+                />
+              </div>
+              <div className="flex-1 border cursor-pointer" onClick={openFull}>
+                <iframe
+                  title="Visor PDF avanzado"
+                  src={`/visor/index.html?path=${encodeURIComponent(
+                    currentPdf.path,
+                  )}&name=${encodeURIComponent(currentPdf.name)}&page=${
+                    pdfMeta[currentPdf.path]?.lastPage || 1
+                  }`}
+                  className="w-full h-full border-0 pointer-events-none"
+                />
+              </div>
+              {remaining !== null && (
+                <div
+                  className={`p-2 text-center ${
+                    remaining >= 3
+                      ? "text-green-500"
+                      : remaining === 2
+                      ? "text-yellow-500"
+                      : "text-red-500"
+                  }`}
+                >
+                  Días restantes: {remaining}
+                </div>
+              )}
+            </>
+          ) : (
+            <p>Sin selección</p>
+          )}
+        </section>
+      </div>
     </main>
   )
 }
 
-/**
- * Pequeño helper para disparar efectos imperativos cuando un "when" cambia,
- * sin forzar re-render del componente principal.
- */
-function RenderEffect({
-  when,
-  onEffect
-}: {
-  when: string | number | boolean
-  onEffect: () => void
-}) {
-  const prev = useRef<string | number | boolean | null>(null)
-  useEffect(() => {
-    if (prev.current !== when) {
-      prev.current = when
-      onEffect()
-    }
-  }, [when, onEffect])
-  return null
-}

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -1,0 +1,51 @@
+import { promises as fs } from 'fs'
+import path from 'path'
+import os from 'os'
+
+// Default to a writable tmp directory but allow the base ``gestor`` path
+// to be overridden at runtime. The path is resolved as
+//   <basePath>/system/notas/config.json
+const fallbackDir =
+  process.env.CONFIG_DIR || path.join(os.tmpdir(), 'gestor', 'system', 'notas')
+
+function resolveConfigPath(base?: string) {
+  const dir = base
+    ? path.join(base, 'system', 'notas')
+    : process.env.BASE_PATH
+    ? path.join(process.env.BASE_PATH, 'system', 'notas')
+    : fallbackDir
+  return path.join(dir, 'config.json')
+}
+
+export async function readConfig(base?: string) {
+  const configPath = resolveConfigPath(base)
+  try {
+    const data = await fs.readFile(configPath, 'utf-8')
+    const json = JSON.parse(data)
+    if (json.basePath && !process.env.BASE_PATH) {
+      process.env.BASE_PATH = json.basePath
+    }
+    if (base && !process.env.BASE_PATH) {
+      process.env.BASE_PATH = base
+    }
+    return json
+  } catch {
+    if (base) process.env.BASE_PATH = base
+    return {}
+  }
+}
+
+export async function writeConfig(data: any) {
+  if (data.basePath) {
+    process.env.BASE_PATH = data.basePath
+  }
+  const configPath = resolveConfigPath(data.basePath)
+  try {
+    await fs.mkdir(path.dirname(configPath), { recursive: true })
+    await fs.writeFile(configPath, JSON.stringify(data, null, 2), 'utf-8')
+    return true
+  } catch (err) {
+    console.error('writeConfig failed:', err)
+    return false
+  }
+}

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "lucide-react": "^0.454.0",
     "next": "15.2.4",
     "next-themes": "latest",
+    "pdf-lib": "1.17.1",
     "pdfjs-dist": "latest",
     "react": "^19",
     "react-day-picker": "9.8.0",
@@ -59,6 +60,7 @@
     "tailwind-merge": "^2.5.5",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^0.9.9",
+    "xlsx": "0.18.5",
     "zod": "3.25.67"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -125,6 +125,9 @@ importers:
       next-themes:
         specifier: latest
         version: 0.4.6(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      pdf-lib:
+        specifier: 1.17.1
+        version: 1.17.1
       pdfjs-dist:
         specifier: latest
         version: 5.4.54
@@ -158,6 +161,9 @@ importers:
       vaul:
         specifier: ^0.9.9
         version: 0.9.9(@types/react-dom@19.0.0)(@types/react@19.0.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      xlsx:
+        specifier: 0.18.5
+        version: 0.18.5
       zod:
         specifier: 3.25.67
         version: 3.25.67
@@ -463,6 +469,12 @@ packages:
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
+
+  '@pdf-lib/standard-fonts@1.0.0':
+    resolution: {integrity: sha512-hU30BK9IUN/su0Mn9VdlVKsWBS6GyhVfqjwl1FjZN4TxP6cCw0jP2w7V3Hf5uX7M0AZJ16vey9yE0ny7Sa59ZA==}
+
+  '@pdf-lib/upng@1.0.1':
+    resolution: {integrity: sha512-dQK2FUMQtowVP00mtIksrlZhdFXQZPC+taih1q4CvPZ5vqdxR/LKBaFg0oAfzd1GlHZXXSPdQfzQnt+ViGvEIQ==}
 
   '@radix-ui/number@1.1.0':
     resolution: {integrity: sha512-V3gRzhVNU1ldS5XhAPTom1fOIo4ccrjjJgmE+LI2h/WaFpHmx0MQApT+KZHnx8abG6Avtfcz4WoEciMnpFT3HQ==}
@@ -1250,6 +1262,10 @@ packages:
   '@types/react@19.0.0':
     resolution: {integrity: sha512-MY3oPudxvMYyesqs/kW1Bh8y9VqSmf+tzqw3ae8a9DZW68pUe3zAdHeI1jc6iAysuRdACnVknHP8AhwD4/dxtg==}
 
+  adler-32@1.3.1:
+    resolution: {integrity: sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==}
+    engines: {node: '>=0.8'}
+
   aria-hidden@1.2.6:
     resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
     engines: {node: '>=10'}
@@ -1273,6 +1289,10 @@ packages:
   caniuse-lite@1.0.30001733:
     resolution: {integrity: sha512-e4QKw/O2Kavj2VQTKZWrwzkt3IxOmIlU6ajRb6LP64LHpBo1J67k2Hi4Vu/TgJWsNtynurfS0uK3MaUTCPfu5Q==}
 
+  cfb@1.2.2:
+    resolution: {integrity: sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==}
+    engines: {node: '>=0.8'}
+
   chownr@3.0.0:
     resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
     engines: {node: '>=18'}
@@ -1293,6 +1313,10 @@ packages:
       react: ^18 || ^19 || ^19.0.0-rc
       react-dom: ^18 || ^19 || ^19.0.0-rc
 
+  codepage@1.15.0:
+    resolution: {integrity: sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==}
+    engines: {node: '>=0.8'}
+
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
@@ -1306,6 +1330,11 @@ packages:
   color@4.2.3:
     resolution: {integrity: sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==}
     engines: {node: '>=12.5.0'}
+
+  crc-32@1.2.2:
+    resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
+    engines: {node: '>=0.8'}
+    hasBin: true
 
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
@@ -1403,6 +1432,10 @@ packages:
   fast-equals@5.2.2:
     resolution: {integrity: sha512-V7/RktU11J3I36Nwq2JnZEM7tNm17eBJz+u25qdxBZeCKiX6BkVSZQjwWIr+IobgnZy+ag73tTZgZi7tr0LrBw==}
     engines: {node: '>=6.0.0'}
+
+  frac@1.1.2:
+    resolution: {integrity: sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==}
+    engines: {node: '>=0.8'}
 
   fraction.js@4.3.7:
     resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}
@@ -1574,6 +1607,12 @@ packages:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
 
+  pako@1.0.11:
+    resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
+
+  pdf-lib@1.17.1:
+    resolution: {integrity: sha512-V/mpyJAoTsN4cnP31vc0wfNA1+p20evqqnap0KLoRUN0Yk/p3wN52DOEsL4oBFcLdb76hlpKPtzJIgo67j/XLw==}
+
   pdfjs-dist@5.4.54:
     resolution: {integrity: sha512-TBAiTfQw89gU/Z4LW98Vahzd2/LoCFprVGvGbTgFt+QCB1F+woyOPmNNVgLa6djX9Z9GGTnj7qE1UzpOVJiINw==}
     engines: {node: '>=20.16.0 || >=22.3.0'}
@@ -1705,6 +1744,10 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
+  ssf@0.11.2:
+    resolution: {integrity: sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==}
+    engines: {node: '>=0.8'}
+
   streamsearch@1.1.0:
     resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
     engines: {node: '>=10.0.0'}
@@ -1743,6 +1786,9 @@ packages:
 
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
+
+  tslib@1.14.1:
+    resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -1797,6 +1843,19 @@ packages:
 
   victory-vendor@36.9.2:
     resolution: {integrity: sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==}
+
+  wmf@1.0.2:
+    resolution: {integrity: sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==}
+    engines: {node: '>=0.8'}
+
+  word@0.3.0:
+    resolution: {integrity: sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==}
+    engines: {node: '>=0.8'}
+
+  xlsx@0.18.5:
+    resolution: {integrity: sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==}
+    engines: {node: '>=0.8'}
+    hasBin: true
 
   yallist@5.0.0:
     resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
@@ -2006,6 +2065,14 @@ snapshots:
 
   '@next/swc-win32-x64-msvc@15.2.4':
     optional: true
+
+  '@pdf-lib/standard-fonts@1.0.0':
+    dependencies:
+      pako: 1.0.11
+
+  '@pdf-lib/upng@1.0.1':
+    dependencies:
+      pako: 1.0.11
 
   '@radix-ui/number@1.1.0': {}
 
@@ -2813,6 +2880,8 @@ snapshots:
     dependencies:
       csstype: 3.1.3
 
+  adler-32@1.3.1: {}
+
   aria-hidden@1.2.6:
     dependencies:
       tslib: 2.8.1
@@ -2840,6 +2909,11 @@ snapshots:
 
   caniuse-lite@1.0.30001733: {}
 
+  cfb@1.2.2:
+    dependencies:
+      adler-32: 1.3.1
+      crc-32: 1.2.2
+
   chownr@3.0.0: {}
 
   class-variance-authority@0.7.1:
@@ -2862,6 +2936,8 @@ snapshots:
       - '@types/react'
       - '@types/react-dom'
 
+  codepage@1.15.0: {}
+
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
@@ -2881,6 +2957,8 @@ snapshots:
       color-convert: 2.0.1
       color-string: 1.9.1
     optional: true
+
+  crc-32@1.2.2: {}
 
   csstype@3.1.3: {}
 
@@ -2961,6 +3039,8 @@ snapshots:
   eventemitter3@4.0.7: {}
 
   fast-equals@5.2.2: {}
+
+  frac@1.1.2: {}
 
   fraction.js@4.3.7: {}
 
@@ -3090,6 +3170,15 @@ snapshots:
   normalize-range@0.1.2: {}
 
   object-assign@4.1.1: {}
+
+  pako@1.0.11: {}
+
+  pdf-lib@1.17.1:
+    dependencies:
+      '@pdf-lib/standard-fonts': 1.0.0
+      '@pdf-lib/upng': 1.0.1
+      pako: 1.0.11
+      tslib: 1.14.1
 
   pdfjs-dist@5.4.54:
     optionalDependencies:
@@ -3249,6 +3338,10 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
+  ssf@0.11.2:
+    dependencies:
+      frac: 1.1.2
+
   streamsearch@1.1.0: {}
 
   styled-jsx@5.1.6(react@19.0.0):
@@ -3276,6 +3369,8 @@ snapshots:
       yallist: 5.0.0
 
   tiny-invariant@1.3.3: {}
+
+  tslib@1.14.1: {}
 
   tslib@2.8.1: {}
 
@@ -3335,6 +3430,20 @@ snapshots:
       d3-shape: 3.2.0
       d3-time: 3.1.0
       d3-timer: 3.0.1
+
+  wmf@1.0.2: {}
+
+  word@0.3.0: {}
+
+  xlsx@0.18.5:
+    dependencies:
+      adler-32: 1.3.1
+      cfb: 1.2.2
+      codepage: 1.15.0
+      crc-32: 1.2.2
+      ssf: 0.11.2
+      wmf: 1.0.2
+      word: 0.3.0
 
   yallist@5.0.0: {}
 

--- a/public/visor/index.html
+++ b/public/visor/index.html
@@ -114,6 +114,7 @@
     }
     .fullscreen #app-header { display: none; }
     .fullscreen #pdf-container { top: 0 !important; }
+    .fullscreen .nav-indicator { display: none; }
 
     .nav-indicator {
       position: absolute; top: 20px; right: 20px;
@@ -506,6 +507,8 @@
       // Persistencia de notas
       let directoryHandle = null;
       let currentPdfName = null;
+      let currentPdfPath = null;
+      let pdfMeta = {};
       let saveTimeout = null;
       let db = null;
 
@@ -758,10 +761,26 @@
         }
       }
 
+      container.addEventListener('scroll', () => {
+        if (!currentPdfPath) return;
+        const p = getCurrentPage();
+        if (p !== currentPage) {
+          currentPage = p;
+          try {
+            pdfMeta[currentPdfPath] = {
+              ...(pdfMeta[currentPdfPath] || {}),
+              lastPage: p,
+            };
+            localStorage.setItem('pdfMeta', JSON.stringify(pdfMeta));
+            localStorage.setItem('lastOpened', currentPdfPath);
+          } catch {}
+        }
+      });
+
       // ========================================
       // CARGA DE PDF
       // ========================================
-      async function loadPdf(url, filename) {
+      async function loadPdf(url, filename, pdfPath, pageParam) {
         try {
           showOverlay('Cargando PDF…');
           clearContainer();
@@ -774,11 +793,21 @@
           backBtn.disabled = false;
           fileInfo.textContent = filename;
           currentPdfName = filename;
+          currentPdfPath = pdfPath || filename;
+          try { pdfMeta = JSON.parse(localStorage.getItem('pdfMeta') || '{}'); } catch {}
+          localStorage.setItem('lastOpened', currentPdfPath);
 
           const loadingTask = pdfjsLib.getDocument(url);
           pdfDoc = await loadingTask.promise;
           totalPages = pdfDoc.numPages;
-          currentPage = 1;
+          const saved = pdfMeta[currentPdfPath]?.lastPage || 1;
+          const startPage = pageParam || saved;
+          currentPage = Math.min(Math.max(startPage, 1), totalPages);
+          pdfMeta[currentPdfPath] = {
+            ...(pdfMeta[currentPdfPath] || {}),
+            lastPage: currentPage,
+          };
+          try { localStorage.setItem('pdfMeta', JSON.stringify(pdfMeta)); } catch {}
 
           // Tamaño base
           try {
@@ -791,11 +820,10 @@
           buildPageSkeletons();
           prepareInitialReveal();
 
-          if (pendingAfterLoadGoTo === 'last') {
-            setTimeout(() => scrollToPage(totalPages), 0);
-          } else {
-            setTimeout(() => scrollToPage(1), 0);
-          }
+          let initial = currentPage;
+          if (pendingAfterLoadGoTo === 'last') initial = totalPages;
+          else if (pendingAfterLoadGoTo === 'first') initial = 1;
+          setTimeout(() => scrollToPage(initial), 0);
           pendingAfterLoadGoTo = null;
 
           if (directoryHandle) {
@@ -1023,6 +1051,11 @@
       }
 
       fullscreenBtn.addEventListener('click', toggleFullscreen);
+      document.addEventListener('keydown', (e) => {
+        if (e.key === 'f' || e.key === 'F') {
+          toggleFullscreen();
+        }
+      });
       function toggleFullscreen() {
         isFullscreen = !isFullscreen;
         if (isFullscreen) { document.body.classList.add('fullscreen'); fullscreenBtn.textContent = '⛷'; }
@@ -1030,22 +1063,7 @@
       }
 
       backBtn.addEventListener('click', () => {
-        dropZone.classList.remove('hidden');
-        clearContainer();
-        fileInfo.textContent = 'Visor PDF';
-        backBtn.disabled = true;
-        pdfDoc = null;
-        hidePopup();
-        creatingNote = false;
-        document.body.classList.remove('creating-note');
-        clearAllSelections();
-        exitCaptureMode(false);
-        currentPage = 1;
-        totalPages = 0;
-        currentPdfName = null;
-        hideOverlay();
-        if (directoryHandle) updateFileStatus('saved', 'Carpeta configurada');
-        else updateFileStatus('no-access', 'Sin acceso');
+        window.location.href = '/';
       });
 
       // ========================================
@@ -1063,7 +1081,7 @@
             const url = URL.createObjectURL(file);
             currentObjectUrl = url;
             currentPdfIndex = -1;
-            loadPdf(url, file.name);
+            loadPdf(url, file.name, file.name);
           } else {
             showToast('Por favor selecciona un archivo PDF', 'error');
           }
@@ -1076,7 +1094,7 @@
             const url = URL.createObjectURL(file);
             currentObjectUrl = url;
             currentPdfIndex = -1;
-            loadPdf(url, file.name);
+            loadPdf(url, file.name, file.name);
           } else {
             showToast('Por favor selecciona un archivo PDF', 'error');
           }
@@ -1088,28 +1106,10 @@
       // ========================================
       function naturalCompare(a, b) { return a.localeCompare(b, undefined, { numeric: true, sensitivity: 'base' }); }
       function isPdf(name) { return name.toLowerCase().endsWith('.pdf'); }
-      function supportsDirPicker() { return 'showDirectoryPicker' in window; }
-      function supportsFileSystemAccess() { return 'showDirectoryPicker' in window; }
+      function supportsDirPicker() { return false; }
+      function supportsFileSystemAccess() { return false; }
 
-      pdfFolderBtn.addEventListener('click', async () => {
-        try {
-          if (!supportsDirPicker()) { pdfFolderInput.click(); return; }
-          const dirHandle = await window.showDirectoryPicker({ mode: 'read' });
-          pdfDirectoryHandle = dirHandle;
-          const list = [];
-          // @ts-ignore
-          for await (const [name, handle] of dirHandle.entries()) {
-            if (handle.kind === 'file' && isPdf(name)) list.push({ name, handle });
-          }
-          if (!list.length) { showToast('La carpeta no contiene PDFs', 'error'); startBtn.disabled = true; pdfEntries = []; return; }
-          list.sort((a,b) => naturalCompare(a.name,b.name));
-          pdfEntries = list; startBtn.disabled = false;
-          showToast(`Listados ${pdfEntries.length} PDFs`, 'success');
-        } catch (e) {
-          if (e && e.name === 'AbortError') return;
-          showToast('No se pudo acceder a la carpeta de PDFs', 'error');
-        }
-      });
+      pdfFolderBtn.addEventListener('click', () => {});
 
       pdfFolderInput.addEventListener('change', (e) => {
         const files = Array.from(e.target.files || []).filter(f => isPdf(f.name));
@@ -1147,7 +1147,7 @@
           const url = URL.createObjectURL(blob);
           currentObjectUrl = url;
           pendingAfterLoadGoTo = after;
-          await loadPdf(url, entry.name);
+          await loadPdf(url, entry.name, entry.name);
           currentPdfIndex = index;
           showNavIndicator(`PDF ${index + 1}/${pdfEntries.length}: ${entry.name}`);
         } catch (e) {
@@ -1607,36 +1607,17 @@
         }
       }
       async function requestDirectoryAccess() {
-        try {
-          const newDirectoryHandle = await window.showDirectoryPicker({ mode: 'readwrite' });
-          const permission = await newDirectoryHandle.requestPermission({ mode: 'readwrite' });
-          if (permission === 'granted') {
-            directoryHandle = newDirectoryHandle;
-            const transaction = db.transaction(['settings'], 'readwrite');
-            const store = transaction.objectStore('settings');
-            await store.put({ id: 'notesFolder', handle: directoryHandle });
-            updateFileStatus('saved', 'Acceso concedido');
-            await loadPromptConfig();
-            showToast('Carpeta configurada correctamente', 'success');
-            hidePermissionModal();
-            if (currentPdfName) setTimeout(loadNotesFromFile, 500);
-          } else {
-            throw new Error('Permisos denegados');
-          }
-        } catch (error) {
-          console.error('Error solicitando acceso:', error);
-          if (error.name !== 'AbortError') {
-            showToast('Error configurando carpeta', 'error');
-            updateFileStatus('error', 'Error de acceso');
-          }
-        }
+        directoryHandle = true;
+        updateFileStatus('saved', 'Acceso concedido');
+        hidePermissionModal();
+        if (currentPdfName) setTimeout(loadNotesFromFile, 500);
       }
       function getNotesFileName(pdfName) {
         const cleanName = pdfName.replace(/[^a-zA-Z0-9.-]/g, '_');
         return `${cleanName}_notas.json`;
       }
       async function saveNotesToFile() {
-        if (!directoryHandle || !currentPdfName) { updateFileStatus('no-access', 'Sin acceso'); return; }
+        if (!currentPdfName) { updateFileStatus('no-access', 'Sin acceso'); return; }
         if (saveTimeout) clearTimeout(saveTimeout);
         saveTimeout = setTimeout(async () => {
           try {
@@ -1644,10 +1625,7 @@
             const notes = collectAllNotes();
             const data = { pdfName: currentPdfName, timestamp: Date.now(), notes, totalPages, zoom: currentZoom, version: '2.2' };
             const fileName = getNotesFileName(currentPdfName);
-            const fileHandle = await directoryHandle.getFileHandle(fileName, { create: true });
-            const writable = await fileHandle.createWritable();
-            await writable.write(JSON.stringify(data, null, 2));
-            await writable.close();
+            await fetch('/api/note', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ name: fileName, data }) });
             updateFileStatus('saved', `${notes.length} notas guardadas`);
           } catch (error) {
             console.error('Error guardando notas:', error);
@@ -1657,13 +1635,11 @@
         }, 600);
       }
       async function loadNotesFromFile() {
-        if (!directoryHandle || !currentPdfName) { updateFileStatus('no-access', 'Sin acceso'); return; }
+        if (!currentPdfName) { updateFileStatus('no-access', 'Sin acceso'); return; }
         try {
           const fileName = getNotesFileName(currentPdfName);
-          const fileHandle = await directoryHandle.getFileHandle(fileName);
-          const file = await fileHandle.getFile();
-          const text = await file.text();
-          const data = JSON.parse(text);
+          const res = await fetch(`/api/note?name=${encodeURIComponent(fileName)}`);
+          const data = await res.json();
           if (data.notes && Array.isArray(data.notes)) {
             document.querySelectorAll('.note-icon').forEach(icon => icon.remove());
             data.notes.forEach(note => {
@@ -1674,6 +1650,15 @@
                 const y = yp * layer.offsetHeight;
                 addNoteIcon(x, y, note.content, layer, xp, yp);
               }
+            });
+            updateFileStatus('saved', `${data.notes.length} notas cargadas`);
+          } else {
+            updateFileStatus('saved', 'Sin notas previas');
+          }
+        } catch (error) {
+          updateFileStatus('error', 'Error cargando');
+        }
+      }
             });
             updateFileStatus('saved', `${data.notes.length} notas cargadas`);
           } else {
@@ -1769,74 +1754,10 @@
       }
 
       async function ensureCategoryHandle(cat) {
-        if (!db) await initDB();
-        await loadCategoryHandles(); // precarga si existen
-        let handle = (cat === 'teo') ? theoryHandle : practiceHandle;
-        if (handle) {
-          const perm = await handle.queryPermission({ mode: 'readwrite' });
-          if (perm === 'granted') return handle;
-        }
-        // Solicitar nueva carpeta
-        try {
-          const picked = await window.showDirectoryPicker({ mode: 'readwrite' });
-          const perm2 = await picked.requestPermission({ mode: 'readwrite' });
-          if (perm2 !== 'granted') throw new Error('Permiso denegado');
-          // Persistir
-          const tx = db.transaction(['settings'], 'readwrite');
-          const store = tx.objectStore('settings');
-          const id = (cat === 'teo') ? 'teoFolder' : 'practicaFolder';
-          await store.put({ id, handle: picked });
-          if (cat === 'teo') theoryHandle = picked; else practiceHandle = picked;
-          showToast('Carpeta guardada para ' + (cat === 'teo' ? 'Teoría' : 'Práctica'), 'success');
-          return picked;
-        } catch (e) {
-          console.error('Error seleccionando carpeta:', e);
-          showToast('No se seleccionó carpeta', 'error');
-          return null;
-        }
+        return true;
       }
 
-      async function loadCategoryHandles() {
-        if (!db || !supportsFileSystemAccess()) return;
-        try {
-          await new Promise((resolve) => {
-            const tx = db.transaction(['settings'], 'readonly');
-            const store = tx.objectStore('settings');
-
-            const reqTeo = store.get('teoFolder');
-            const reqPra = store.get('practicaFolder');
-
-            let done = 0;
-            function checkDone() { if (++done === 2) resolve(); }
-
-            reqTeo.onsuccess = async () => {
-              const result = reqTeo.result;
-              if (result && result.handle) {
-                try {
-                  const status = await result.handle.queryPermission({ mode: 'readwrite' });
-                  if (status === 'granted') theoryHandle = result.handle;
-                } catch {}
-              }
-              checkDone();
-            };
-            reqTeo.onerror = checkDone;
-
-            reqPra.onsuccess = async () => {
-              const result = reqPra.result;
-              if (result && result.handle) {
-                try {
-                  const status = await result.handle.queryPermission({ mode: 'readwrite' });
-                  if (status === 'granted') practiceHandle = result.handle;
-                } catch {}
-              }
-              checkDone();
-            };
-            reqPra.onerror = checkDone;
-          });
-        } catch (e) {
-          console.warn('No se pudieron cargar carpetas de categorías');
-        }
-      }
+      async function loadCategoryHandles() {}
 
       function addSelectionRect(layer, pageNum, xp1, yp1, xp2, yp2) {
         const rect = document.createElement('div');
@@ -1874,32 +1795,25 @@
       }
 
       async function saveSelectionsToCategory() {
-        const handle = captureCategory === 'teo' ? theoryHandle : practiceHandle;
-        if (!handle) throw new Error('Carpeta no configurada');
-
         if (!currentPdfName) throw new Error('No hay PDF cargado');
 
         showOverlay('Guardando capturas…');
 
         try {
-          // Guardar secuencialmente
           const base = sanitizeName(currentPdfName.replace(/\.pdf$/i, ''));
           for (let i = 0; i < selections.length; i++) {
             const s = selections[i];
             const state = pageStates.get(s.pageNum);
             if (!state) continue;
-            // Render forzado si el canvas está liberado
             if (!state.canvas.width || !state.canvas.height) {
               await renderPage(s.pageNum, state);
             }
             const canvas = state.canvas;
-            // Coordenadas en píxeles del canvas
             const sx = Math.round(Math.min(s.xp1, s.xp2) * canvas.width);
             const sy = Math.round(Math.min(s.yp1, s.yp2) * canvas.height);
             const sw = Math.max(1, Math.round(Math.abs(s.xp2 - s.xp1) * canvas.width));
             const sh = Math.max(1, Math.round(Math.abs(s.yp2 - s.yp1) * canvas.height));
 
-            // Crear canvas offscreen
             const out = document.createElement('canvas');
             out.width = sw; out.height = sh;
             const octx = out.getContext('2d');
@@ -1907,10 +1821,10 @@
 
             const blob = await new Promise(resolve => out.toBlob(resolve, 'image/png', 0.92));
             const fileName = `${base}_p${s.pageNum}_${String(i + 1).padStart(2, '0')}.png`;
-            const fileHandle = await handle.getFileHandle(fileName, { create: true });
-            const writable = await fileHandle.createWritable();
-            await writable.write(blob);
-            await writable.close();
+            const form = new FormData();
+            form.append('file', blob, fileName);
+            form.append('category', captureCategory);
+            await fetch('/api/capture', { method: 'POST', body: form });
 
             if (loadingText) loadingText.textContent = `Guardando… (${i + 1}/${selections.length})`;
           }
@@ -2084,6 +1998,16 @@
         await writable.close();
         const file = new File([blob], pdfName, { type: 'application/pdf' });
         return { handle: fileHandle, file, blob };
+      }
+
+      // cargar pdf inicial si viene por query
+      const params = new URLSearchParams(window.location.search);
+      const pathParam = params.get('path');
+      const nameParam = params.get('name');
+      const pageParam = parseInt(params.get('page') || '0');
+      if (pathParam && nameParam) {
+        const url = `/api/pdf?path=${encodeURIComponent(pathParam)}`;
+        loadPdf(url, nameParam, pathParam, pageParam);
       }
 
       // ========================================


### PR DESCRIPTION
## Summary
- allow picking the gestor directory up front and restore any existing progress from its config
- resolve all file, note and PDF requests relative to the configured gestor path so data is read and written beside the user's files

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Can't resolve 'xlsx' & 'pdf-lib')*

------
https://chatgpt.com/codex/tasks/task_e_6899dccd494083309064ffd54ea758fa