### PR TITLE
Add config reload and improved schedule view

### DIFF
--- a/public/visor/index.html
+++ b/public/visor/index.html
@@ -103,6 +103,10 @@
     body:not(.light-mode) .page-wrapper canvas {
       filter: invert(1) hue-rotate(180deg);
     }
+    body:not(.light-mode) .textLayer,
+    body:not(.light-mode) .annotationLayer {
+      filter: invert(1) hue-rotate(180deg);
+    }
     .anno-layer { position: absolute; top: 0; left: 0; pointer-events: none; }
     .page-number {
       position: absolute; bottom: -24px; left: 50%; transform: translateX(-50%);
@@ -1557,140 +1561,63 @@
       // ========================================
       // PERSISTENCIA DE NOTAS
       // ========================================
-      function showPermissionModal() {
-        if (!supportsFileSystemAccess()) {
-          showToast('Tu navegador no soporta guardado automático de archivos', 'error');
-          updateFileStatus('error', 'No compatible');
-          return;
-        }
-        document.getElementById('permission-modal').classList.remove('hidden');
-      }
-      function hidePermissionModal() {
-        document.getElementById('permission-modal').classList.add('hidden');
-      }
-      async function initDB() {
-        return new Promise((resolve, reject) => {
-          const request = indexedDB.open('PDFViewerDB', 1);
-          request.onerror = () => reject(request.error);
-          request.onsuccess = () => { db = request.result; resolve(db); };
-          request.onupgradeneeded = (event) => {
-            const db = event.target.result;
-            if (!db.objectStoreNames.contains('settings')) db.createObjectStore('settings', { keyPath: 'id' });
-          };
-        });
-      }
+      function showPermissionModal() {}
+      function hidePermissionModal() {}
+      async function initDB() {}
       async function loadDirectoryHandle() {
-        if (!db || !supportsFileSystemAccess()) { updateFileStatus('no-access', 'Sin acceso'); return;
-        }
-        try {
-          const transaction = db.transaction(['settings'], 'readonly');
-          const store = transaction.objectStore('settings');
-          const request = store.get('notesFolder');
-          request.onsuccess = async () => {
-            const result = request.result;
-            if (result && result.handle) {
-              const handle = result.handle;
-              const permissionStatus = await handle.queryPermission({ mode: 'readwrite' });
-              if (permissionStatus === 'granted') {
-                directoryHandle = handle;
-                updateFileStatus('saved', 'Acceso concedido');
-                await loadPromptConfig();
-              } else {
-                updateFileStatus('no-access', 'Acceso denegado');
-              }
-            } else {
-              updateFileStatus('no-access', 'Sin acceso');
-            }
-          };
-          request.onerror = (e) => {
-            console.error('Error al cargar handle de carpeta:', e.target.error);
-            updateFileStatus('no-access', 'Error de carga');
-          };
-        } catch (error) {
-          console.error('Error al cargar handle de carpeta (catch):', error);
-          updateFileStatus('no-access', 'Error de carga');
-        }
+        updateFileStatus('saved', 'Notas locales');
+        await loadPromptConfig();
       }
-      async function requestDirectoryAccess() {
-        try {
-          const newDirectoryHandle = await window.showDirectoryPicker({ mode: 'readwrite' });
-          const permission = await newDirectoryHandle.requestPermission({ mode: 'readwrite' });
-          if (permission === 'granted') {
-            directoryHandle = newDirectoryHandle;
-            const transaction = db.transaction(['settings'], 'readwrite');
-            const store = transaction.objectStore('settings');
-            await store.put({ id: 'notesFolder', handle: directoryHandle });
-            updateFileStatus('saved', 'Acceso concedido');
-            await loadPromptConfig();
-            showToast('Carpeta configurada correctamente', 'success');
-            hidePermissionModal();
-            if (currentPdfName) setTimeout(loadNotesFromFile, 500);
-          } else {
-            throw new Error('Permisos denegados');
-          }
-        } catch (error) {
-          console.error('Error solicitando acceso:', error);
-          if (error.name !== 'AbortError') {
-            showToast('Error configurando carpeta', 'error');
-            updateFileStatus('error', 'Error de acceso');
-          }
-        }
-      }
+      async function requestDirectoryAccess() {}
       function getNotesFileName(pdfName) {
         const cleanName = pdfName.replace(/[^a-zA-Z0-9.-]/g, '_');
         return `${cleanName}_notas.json`;
       }
       async function saveNotesToFile() {
-        if (!directoryHandle || !currentPdfName) { updateFileStatus('no-access', 'Sin acceso'); return; }
+        if (!currentPdfName) return;
         if (saveTimeout) clearTimeout(saveTimeout);
-        saveTimeout = setTimeout(async () => {
+        saveTimeout = setTimeout(() => {
           try {
             updateFileStatus('saving', 'Guardando...');
             const notes = collectAllNotes();
             const data = { pdfName: currentPdfName, timestamp: Date.now(), notes, totalPages, zoom: currentZoom, version: '2.2' };
-            const fileName = getNotesFileName(currentPdfName);
-            const fileHandle = await directoryHandle.getFileHandle(fileName, { create: true });
-            const writable = await fileHandle.createWritable();
-            await writable.write(JSON.stringify(data, null, 2));
-            await writable.close();
+            const key = `/gestor/system/notas/${getNotesFileName(currentPdfName)}`;
+            localStorage.setItem(key, JSON.stringify(data));
             updateFileStatus('saved', `${notes.length} notas guardadas`);
           } catch (error) {
             console.error('Error guardando notas:', error);
             updateFileStatus('error', 'Error guardando');
-            showToast('Error guardando notas automáticamente', 'error');
           }
         }, 600);
       }
       async function loadNotesFromFile() {
-        if (!directoryHandle || !currentPdfName) { updateFileStatus('no-access', 'Sin acceso'); return; }
+        if (!currentPdfName) return;
         try {
-          const fileName = getNotesFileName(currentPdfName);
-          const fileHandle = await directoryHandle.getFileHandle(fileName);
-          const file = await fileHandle.getFile();
-          const text = await file.text();
-          const data = JSON.parse(text);
-          if (data.notes && Array.isArray(data.notes)) {
-            document.querySelectorAll('.note-icon').forEach(icon => icon.remove());
-            data.notes.forEach(note => {
-              const layer = document.querySelector(`[data-page="${note.pageNum}"]`);
-              if (layer) {
-                const xp = note.x; const yp = note.y;
-                const x = xp * layer.offsetWidth;
-                const y = yp * layer.offsetHeight;
-                addNoteIcon(x, y, note.content, layer, xp, yp);
+            const key = `/gestor/system/notas/${getNotesFileName(currentPdfName)}`;
+            const text = localStorage.getItem(key);
+            if (text) {
+              const data = JSON.parse(text);
+              if (data.notes && Array.isArray(data.notes)) {
+                document.querySelectorAll('.note-icon').forEach(icon => icon.remove());
+                data.notes.forEach(note => {
+                  const layer = document.querySelector(`[data-page="${note.pageNum}"]`);
+                  if (layer) {
+                    const xp = note.x; const yp = note.y;
+                    const x = xp * layer.offsetWidth;
+                    const y = yp * layer.offsetHeight;
+                    addNoteIcon(x, y, note.content, layer, xp, yp);
+                  }
+                });
+                updateFileStatus('saved', `${data.notes.length} notas cargadas`);
+              } else {
+                updateFileStatus('saved', 'Sin notas previas');
               }
-            });
-            updateFileStatus('saved', `${data.notes.length} notas cargadas`);
-          } else {
-            updateFileStatus('saved', 'Sin notas previas');
-          }
+            } else {
+              updateFileStatus('saved', 'Sin notas previas');
+            }
         } catch (error) {
-          if (error.name === 'NotFoundError') {
-            updateFileStatus('saved', 'Sin notas previas');
-          } else {
             console.error('Error cargando notas:', error);
             updateFileStatus('error', 'Error cargando');
-          }
         }
       }
       function collectAllNotes() {
@@ -1707,11 +1634,12 @@
         });
         return notes;
       }
-      document.getElementById('folder-btn').addEventListener('click', () => { showPermissionModal(); });
-      document.getElementById('grant-access-btn').addEventListener('click', requestDirectoryAccess);
-      document.getElementById('skip-access-btn').addEventListener('click', () => {
-        hidePermissionModal(); updateFileStatus('no-access', 'Sin acceso'); showToast('Puedes configurar la carpeta más tarde', 'info');
-      });
+      const folderBtn = document.getElementById('folder-btn');
+      folderBtn && folderBtn.addEventListener('click', () => {});
+      const grantBtn = document.getElementById('grant-access-btn');
+      grantBtn && grantBtn.addEventListener('click', () => {});
+      const skipBtn = document.getElementById('skip-access-btn');
+      skipBtn && skipBtn.addEventListener('click', () => {});
 
       // ========================================
       // MODAL INFO
@@ -2102,13 +2030,12 @@
       // ========================================
       // INICIALIZACIÓN
       // ========================================
-      initDB().then(async () => {
-        loadDirectoryHandle();
+      (async () => {
+        await loadDirectoryHandle();
         await loadCategoryHandles();
-      }).catch(error => {
-        console.error('Error al inicializar IndexedDB:', error);
-        showToast('Error al inicializar la base de datos local.', 'error');
-        updateFileStatus('error', 'DB Error');
+      })().catch(error => {
+        console.error('Error al iniciar:', error);
+        updateFileStatus('error', 'Init Error');
       });
     });
   </script>


### PR DESCRIPTION
## Summary
- prevent greeting when opening schedule and keep folder selection
- show inline PDF preview and auto-detect subjects from folder
- fix dark mode filter and store notes without permission prompts

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (interactive prompt)


------
https://chatgpt.com/codex/tasks/task_e_689a6a32113c833082a9ac5a4a6ec7fd