### PR TITLE
Enable dynamic subjects, bulk PDF tagging and streamlined fullscreen viewer

### DIFF
--- a/public/visor/index.html
+++ b/public/visor/index.html
@@ -118,6 +118,7 @@
     }
     .fullscreen #app-header { display: none; }
     .fullscreen #pdf-container { top: 0 !important; }
+    .fullscreen .nav-indicator { display: none; }
 
     .nav-indicator {
       position: absolute; top: 20px; right: 20px;


### PR DESCRIPTION
## Summary
- Allow adding subjects to any week and auto-create entries when missing
- Introduce bulk PDF tagging mode for theory/practice
- Simplify fullscreen PDF view leaving only document name and days remaining

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(interactive prompt: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_689a8e208984833089cbcf20cf7bc0af