### PR TITLE
feat: improve schedule and fullscreen viewer

### DIFF
--- a/public/visor/index.html
+++ b/public/visor/index.html
@@ -116,7 +116,9 @@
     .fullscreen { position: fixed !important; top: 0 !important; left: 0 !important;
       width: 100vw !important; height: 100vh !important; z-index: 9999 !important; background: #525659 !important;
     }
-    .fullscreen #app-header { display: none; }
+    .fullscreen #app-header { display: flex; justify-content: center; }
+    .fullscreen #app-header .header-left,
+    .fullscreen #app-header .header-right { display: none; }
     .fullscreen #pdf-container { top: 0 !important; }
 
     .nav-indicator {


### PR DESCRIPTION
## Summary
- allow adding new subjects to weekly schedule on the fly
- streamline fullscreen PDF viewer and hide extra controls
- add bulk theory/practice labelling when selecting PDFs

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(interactive prompt prevents completion)*

------
https://chatgpt.com/codex/tasks/task_e_689a943a3e1483308e997e2229ed9e4c