### PR TITLE
Fix missing note persistence

### DIFF
--- a/public/visor/index.html
+++ b/public/visor/index.html
@@ -817,12 +817,13 @@
           setTimeout(() => scrollToPage(saved), 0);
           pendingAfterLoadGoTo = null;
 
-          if (directoryHandle) {
-            setTimeout(loadNotesFromFile, 300);
-          } else if (supportsFileSystemAccess()) {
-            setTimeout(showPermissionModal, 1000);
-          } else {
-            updateFileStatus('error', 'No compatible');
+          setTimeout(loadNotesFromFile, 300);
+          if (!directoryHandle) {
+            if (supportsFileSystemAccess()) {
+              setTimeout(showPermissionModal, 1000);
+            } else {
+              updateFileStatus('error', 'No compatible');
+            }
           }
         } catch (error) {
           console.error('Error cargando PDF:', error);


### PR DESCRIPTION
## Summary
- Always load saved notes from localStorage when opening a PDF
- Show permission modal only if no directory is selected

## Testing
- `pnpm lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a4cb409728833080e8f754f2aec4e9