### PR TITLE
Separar teoría y práctica y ocultar barras en pantalla completa

### DIFF
--- a/public/visor/index.html
+++ b/public/visor/index.html
@@ -1039,8 +1039,14 @@
       fullscreenBtn.addEventListener('click', toggleFullscreen);
       function toggleFullscreen() {
         isFullscreen = !isFullscreen;
-        if (isFullscreen) { document.body.classList.add('fullscreen'); fullscreenBtn.textContent = '⛷'; }
-        else { document.body.classList.remove('fullscreen'); fullscreenBtn.textContent = '⛶'; }
+        if (isFullscreen) {
+          document.body.classList.add('fullscreen');
+          fullscreenBtn.textContent = '⛷';
+        } else {
+          document.body.classList.remove('fullscreen');
+          fullscreenBtn.textContent = '⛶';
+        }
+        window.parent.postMessage({ type: 'viewer-fullscreen', isFullscreen }, '*');
       }
 
       backBtn.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- Separa los PDFs por Teoría y Práctica al mostrar una materia
- Oculta barras y controles del visor cuando entra en pantalla completa

## Testing
- `npm test` (error: Missing script)
- `npm run lint` (requiere configuración interactiva)


------
https://chatgpt.com/codex/tasks/task_e_68a4dfd270f88330879624a633558e4d