### PR TITLE
feat: display YouTube shortcuts

### DIFF
--- a/app/api/videos/route.ts
+++ b/app/api/videos/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from "next/server";
+import { readdir } from "fs/promises";
+import path from "path";
+import ws from "windows-shortcuts";
+
+export const runtime = "nodejs";
+
+const SHORTCUT_DIR = process.env.SHORTCUT_DIR || path.join(process.cwd(), "shortcuts");
+
+function parseShortcut(filePath: string): Promise<string | null> {
+  return new Promise((resolve) => {
+    ws.query(filePath, (err, opts) => {
+      if (err) return resolve(null);
+      const args = String(opts?.args || "");
+      const urlMatch = args.match(/https?:\/\/\S+/i);
+      resolve(urlMatch ? urlMatch[0] : null);
+    });
+  });
+}
+
+export async function GET() {
+  try {
+    const files = await readdir(SHORTCUT_DIR);
+    const videos: { title: string; url: string }[] = [];
+    for (const f of files) {
+      if (f.toLowerCase().endsWith(".lnk")) {
+        const fp = path.join(SHORTCUT_DIR, f);
+        const url = await parseShortcut(fp);
+        if (url) {
+          videos.push({ title: path.basename(f, ".lnk"), url });
+        }
+      }
+    }
+    return NextResponse.json({ ok: true, videos });
+  } catch (err: any) {
+    console.error("Failed to read shortcuts", err);
+    return NextResponse.json({ ok: false, error: "Failed to read shortcuts", message: err?.message }, { status: 500 });
+  }
+}

--- a/app/videos/page.tsx
+++ b/app/videos/page.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+interface Video {
+  title: string;
+  url: string;
+}
+
+function toEmbed(url: string): string {
+  const match = url.match(/(?:v=|youtu\.be\/)([A-Za-z0-9_-]{11})/);
+  return match ? `https://www.youtube.com/embed/${match[1]}` : url;
+}
+
+export default function VideosPage() {
+  const [videos, setVideos] = useState<Video[]>([]);
+  const [current, setCurrent] = useState<Video | null>(null);
+
+  useEffect(() => {
+    fetch("/api/videos")
+      .then((r) => r.json())
+      .then((data) => setVideos(data.videos || []))
+      .catch(() => setVideos([]));
+  }, []);
+
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold mb-4">Videos</h1>
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        {videos.map((v) => (
+          <div
+            key={v.title}
+            className="cursor-pointer border rounded p-2 hover:bg-gray-100 dark:hover:bg-gray-800"
+            onClick={() => setCurrent(v)}
+          >
+            <div className="aspect-video flex items-center justify-center bg-black/10">
+              <span className="text-2xl">▶</span>
+            </div>
+            <p className="mt-2 text-sm text-center break-words">{v.title}</p>
+          </div>
+        ))}
+      </div>
+
+      {current && (
+        <div className="fixed inset-0 bg-black/70 flex items-center justify-center z-50">
+          <div className="bg-white dark:bg-gray-900 p-4 rounded shadow-lg max-w-3xl w-full">
+            <button
+              className="mb-2 text-sm text-right w-full"
+              onClick={() => setCurrent(null)}
+            >
+              Cerrar
+            </button>
+            <div className="aspect-video">
+              <iframe
+                className="w-full h-full"
+                src={toEmbed(current.url)}
+                title={current.title}
+                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                allowFullScreen
+              ></iframe>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "tailwind-merge": "^2.5.5",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^0.9.9",
+    "windows-shortcuts": "^0.1.6",
     "xlsx": "0.18.5",
     "zod": "3.25.67"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -161,6 +161,9 @@ importers:
       vaul:
         specifier: ^0.9.9
         version: 0.9.9(@types/react-dom@19.0.0)(@types/react@19.0.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      windows-shortcuts:
+        specifier: ^0.1.6
+        version: 0.1.6
       xlsx:
         specifier: 0.18.5
         version: 0.18.5
@@ -1883,6 +1886,9 @@ packages:
   victory-vendor@36.9.2:
     resolution: {integrity: sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==}
 
+  windows-shortcuts@0.1.6:
+    resolution: {integrity: sha512-kjkb3Hmmmg7jwnOb+29AOmoEEA1L/JeLsMOYovpLxYpuc+fN0R+pr8sMwep3JFhUZloxyw1XTzq8n3HugXkqBA==}
+
   wmf@1.0.2:
     resolution: {integrity: sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==}
     engines: {node: '>=0.8'}
@@ -3501,6 +3507,8 @@ snapshots:
       d3-shape: 3.2.0
       d3-time: 3.1.0
       d3-timer: 3.0.1
+
+  windows-shortcuts@0.1.6: {}
 
   wmf@1.0.2: {}
 

--- a/types/windows-shortcuts.d.ts
+++ b/types/windows-shortcuts.d.ts
@@ -1,0 +1,12 @@
+declare module 'windows-shortcuts' {
+  interface ShortcutOptions {
+    target?: string;
+    args?: string;
+    [key: string]: any;
+  }
+  interface WindowsShortcuts {
+    query(path: string, callback: (err: any, options: ShortcutOptions) => void): void;
+  }
+  const ws: WindowsShortcuts;
+  export default ws;
+}


### PR DESCRIPTION
## Summary
- read Windows `.lnk` shortcut files from a configurable folder and expose their YouTube URLs via `/api/videos`
- show fetched shortcuts as cards that open a modal with an embedded YouTube player
- declare missing types and add `windows-shortcuts` dependency

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68af0fc601e8833096f0dff703ac0381