### PR TITLE
feat: list YouTube shortcuts

### DIFF
--- a/app/api/videos/route.ts
+++ b/app/api/videos/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from "next/server";
+import fs from "fs";
+import path from "path";
+import { execSync } from "child_process";
+
+export async function GET() {
+  const dir = process.env.SHORTCUT_DIR || path.join(process.cwd(), "shortcuts");
+  let items: { title: string; url: string }[] = [];
+  try {
+    const files = fs.readdirSync(dir).filter((f) => f.toLowerCase().endsWith(".lnk"));
+    items = files
+      .map((file) => {
+        const full = path.join(dir, file);
+        let args = "";
+        if (process.platform === "win32") {
+          try {
+            const ps = `$s=(New-Object -ComObject WScript.Shell).CreateShortcut('${full.replace(/'/g, "''")}'); Write-Output $s.Arguments`;
+            args = execSync(`powershell.exe -NoProfile -Command \"${ps}\"`, { encoding: "utf8" }).trim();
+          } catch {}
+        }
+        const match = args.match(/https?:\/\/\S+/);
+        const url = match ? match[0] : "";
+        return { title: path.basename(file, ".lnk"), url };
+      })
+      .filter((v) => v.url);
+  } catch {}
+  return NextResponse.json(items);
+}

--- a/app/videos/page.tsx
+++ b/app/videos/page.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Card } from "@/components/ui/card";
+import * as Dialog from "@radix-ui/react-dialog";
+
+interface Video {
+  title: string;
+  url: string;
+}
+
+function getEmbedUrl(url: string) {
+  const match = url.match(/v=([^&]+)/);
+  const id = match ? match[1] : url;
+  return `https://www.youtube.com/embed/${id}`;
+}
+
+export default function VideosPage() {
+  const [videos, setVideos] = useState<Video[]>([]);
+  const [current, setCurrent] = useState<Video | null>(null);
+
+  useEffect(() => {
+    fetch("/api/videos")
+      .then((res) => res.json())
+      .then(setVideos)
+      .catch(() => setVideos([]));
+  }, []);
+
+  return (
+    <div className="p-4">
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        {videos.map((v) => (
+          <Card
+            key={v.title}
+            className="p-4 cursor-pointer hover:bg-accent"
+            onClick={() => setCurrent(v)}
+          >
+            <p className="text-center">{v.title}</p>
+          </Card>
+        ))}
+      </div>
+
+      <Dialog.Root open={!!current} onOpenChange={() => setCurrent(null)}>
+        <Dialog.Portal>
+          <Dialog.Overlay className="fixed inset-0 bg-black/50" />
+          <Dialog.Content className="fixed left-1/2 top-1/2 w-11/12 max-w-3xl -translate-x-1/2 -translate-y-1/2 bg-background p-4">
+            {current && (
+              <iframe
+                src={getEmbedUrl(current.url)}
+                className="w-full aspect-video"
+                allow="autoplay; encrypted-media"
+                allowFullScreen
+              />
+            )}
+          </Dialog.Content>
+        </Dialog.Portal>
+      </Dialog.Root>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add API endpoint to parse `.lnk` shortcuts and extract YouTube URLs
- render videos page showing shortcut cards and modal player
- add `shortcuts` directory for reading links

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(requires interactive setup)*

------
https://chatgpt.com/codex/tasks/task_e_68af0fc601e8833096f0dff703ac0381