### PR TITLE
feat: render youtube shortcuts in modal

### DIFF
--- a/app/api/videos/route.ts
+++ b/app/api/videos/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from 'next/server'
+import { promises as fs } from 'fs'
+import path from 'path'
+import { extractUrlFromLnk } from '@/lib/lnk'
+
+const SHORTCUT_DIR = process.env.SHORTCUT_DIR || path.join(process.cwd(), 'shortcuts')
+
+export async function GET() {
+  try {
+    const entries = await fs.readdir(SHORTCUT_DIR)
+    const videos = (
+      await Promise.all(
+        entries
+          .filter((f) => f.toLowerCase().endsWith('.lnk'))
+          .map(async (file) => {
+            const filePath = path.join(SHORTCUT_DIR, file)
+            const url = await extractUrlFromLnk(filePath)
+            if (!url) return null
+            return {
+              title: path.parse(file).name,
+              url,
+            }
+          }),
+      )
+    ).filter(Boolean)
+    return NextResponse.json({ videos })
+  } catch (err: any) {
+    return NextResponse.json(
+      { videos: [], error: err.message },
+      { status: 500 },
+    )
+  }
+}

--- a/app/videos/page.tsx
+++ b/app/videos/page.tsx
@@ -1,0 +1,65 @@
+"use client"
+
+import { useEffect, useState } from 'react'
+
+interface Video {
+  title: string
+  url: string | null
+}
+
+function toEmbed(url: string) {
+  try {
+    const u = new URL(url)
+    const id = u.searchParams.get('v')
+    if (id) return `https://www.youtube.com/embed/${id}`
+    return url
+  } catch {
+    return url
+  }
+}
+
+export default function VideosPage() {
+  const [videos, setVideos] = useState<Video[]>([])
+  const [current, setCurrent] = useState<Video | null>(null)
+
+  useEffect(() => {
+    fetch('/api/videos')
+      .then((res) => res.json())
+      .then((data) => setVideos(data.videos || []))
+      .catch(() => setVideos([]))
+  }, [])
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-xl font-semibold">Videos</h1>
+      <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
+        {videos.map((v) => (
+          <button
+            key={v.title}
+            onClick={() => v.url && setCurrent(v)}
+            className="border rounded p-4 hover:bg-gray-100 text-left"
+          >
+            {v.title}
+          </button>
+        ))}
+      </div>
+      {current && current.url && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+          <div className="bg-white p-4 max-w-xl w-full space-y-2">
+            <div className="flex justify-between items-center">
+              <h2 className="font-medium">{current.title}</h2>
+              <button onClick={() => setCurrent(null)}>✕</button>
+            </div>
+            <div className="aspect-video">
+              <iframe
+                src={toEmbed(current.url)}
+                allowFullScreen
+                className="w-full h-full border-0"
+              />
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/lib/lnk.ts
+++ b/lib/lnk.ts
@@ -1,0 +1,46 @@
+import { promises as fs } from 'fs'
+
+/**
+ * Extracts the first HTTP(S) URL from a Windows shortcut (.lnk) file.
+ *
+ * Scanning the entire file as a string proved unreliable because NUL
+ * characters can appear inside the command line arguments. These NULs make a
+ * simple regular expression capture the executable path as part of the match.
+ *
+ * To avoid that, this implementation searches the raw buffer for the UTF-16LE
+ * or UTF-8 representation of "http" and then reads until a string terminator
+ * is found.
+ */
+export async function extractUrlFromLnk(
+  filePath: string,
+): Promise<string | null> {
+  try {
+    const buffer = await fs.readFile(filePath)
+
+    // Look for an UTF-16LE encoded http/https prefix
+    const prefixUtf16 = Buffer.from('http', 'utf16le')
+    let idx = buffer.indexOf(prefixUtf16)
+    if (idx !== -1) {
+      let end = idx
+      // Strings in .lnk are UTF-16LE and terminated with double null
+      while (end + 1 < buffer.length) {
+        if (buffer[end] === 0x00 && buffer[end + 1] === 0x00) break
+        end += 2
+      }
+      return buffer.slice(idx, end).toString('utf16le')
+    }
+
+    // Fallback to UTF-8 search
+    const prefixUtf8 = Buffer.from('http', 'utf8')
+    idx = buffer.indexOf(prefixUtf8)
+    if (idx !== -1) {
+      let end = idx
+      while (end < buffer.length && buffer[end] !== 0x00) end++
+      return buffer.slice(idx, end).toString('utf8')
+    }
+
+    return null
+  } catch {
+    return null
+  }
+}


### PR DESCRIPTION
## Summary
- parse `.lnk` files to extract video URLs
- list shortcuts as cards and play videos in a modal
- reliably detect shortcut URLs and ignore invalid entries

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68af0fc601e8833096f0dff703ac0381