### PR TITLE
Allow embedding non‑PDF files

### DIFF
--- a/public/visor/index.html
+++ b/public/visor/index.html
@@ -323,7 +323,7 @@
       <button class="control-btn" id="pdf-folder-btn" title="Seleccionar carpeta de PDFs">📂 PDFs</button>
       <button class="control-btn" id="start-btn" title="Abrir primer PDF" disabled>▶ iniciar →</button>
       <input type="file" id="pdf-folder-input" class="hidden" style="display:none"
-        accept="application/pdf" multiple webkitdirectory directory />
+        multiple webkitdirectory directory />
 
       <button class="control-btn" id="zoom-out">−</button>
       <span id="zoom-display">100%</span>
@@ -346,10 +346,10 @@
   <div id="drop-zone">
     <div class="upload-area" id="upload-area">
       <div class="upload-icon">📄</div>
-      <div class="upload-text">Seleccionar PDF</div>
+      <div class="upload-text">Seleccionar archivo</div>
       <div class="upload-subtext">Arrastra un archivo aquí o haz clic para seleccionar</div>
     </div>
-    <input type="file" id="file-input" accept="application/pdf">
+    <input type="file" id="file-input">
   </div>
 
   <div id="pdf-container">


### PR DESCRIPTION
## Summary
- include non-PDF files when building the file tree and track whether a file is a PDF
- generate object URLs or parse shortcut files to embed links when opening non-PDFs
- show external content directly in the preview and modal viewer
- remove PDF-only restrictions from file inputs in the standalone viewer

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68af1aac9c508330b99adc69f9097a8c