### PR TITLE
Handle .lnk links by showing YouTube modal

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -372,9 +372,9 @@ useEffect(() => {
     ;(async () => {
       try {
         const buf = await currentPdf.file.arrayBuffer()
-        const text = new TextDecoder().decode(buf)
+        const text = new TextDecoder().decode(buf).replace(/\u0000/g, "")
         const match = text.match(/https?:\/\/[^\s]+/)
-        const raw = match ? match[0].split('\u0000')[0] : null
+        const raw = match ? match[0] : null
         const url = raw ? toEmbedUrl(raw) : null
         setEmbedUrl(url)
       } catch {


### PR DESCRIPTION
## Summary
- Strip null characters from shortcut file contents before extracting URLs
- Use the cleaned URL to embed YouTube videos in the modal instead of the PDF viewer

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68af5831fb248330a71825715b85996f