### PR TITLE
Fix zoom panning for PDFs

### DIFF
--- a/public/visor/index.html
+++ b/public/visor/index.html
@@ -92,7 +92,7 @@
     #pdf-container {
       position: absolute; top: 56px; left: 0; right: 0; bottom: 0;
       overflow-y: auto; overflow-x: auto; display: flex; flex-direction: column;
-      align-items: center; gap: 8px; padding: 16px 0; background: #525659;
+      align-items: flex-start; gap: 8px; padding: 16px 0; background: #525659;
     }
     body.light-mode #pdf-container { background: #fff; }
 
@@ -103,7 +103,7 @@
 
     .page-wrapper {
       position: relative; background: #fff; box-shadow: 0 2px 10px rgba(0,0,0,0.3);
-      margin-bottom: 8px;
+      margin: 0 auto 8px;
     }
     body:not(.light-mode) .page-wrapper {
       background: #1e1e1e;


### PR DESCRIPTION
## Summary
- allow horizontal scrolling when zooming by aligning pages to the left and centering them with auto margins

## Testing
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68b0eb1cb5448330b34f2407ba323af3