### PR TITLE
feat: add basic pdf drawing mode

### DIFF
--- a/public/visor/index.html
+++ b/public/visor/index.html
@@ -188,6 +188,61 @@
     }
     #draw-indicator.active { display: block; }
     .draw-canvas { position: absolute; top: 0; left: 0; z-index: 800; }
+    #draw-controls {
+      position: fixed;
+      top: 60px;
+      right: 20px;
+      background: rgba(50,54,57,0.95);
+      border: 1px solid #5f6368;
+      border-radius: 8px;
+      padding: 10px;
+      z-index: 1101;
+      font-size: 12px;
+      width: 230px;
+      color: #e8eaed;
+      display: none;
+    }
+    #draw-controls.active { display: block; }
+    #draw-controls .color-row {
+      display: flex;
+      justify-content: space-between;
+      margin-bottom: 8px;
+    }
+    #draw-controls .color-row label {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      font-size: 11px;
+      gap: 2px;
+    }
+    #draw-controls input[type="color"] {
+      width: 24px;
+      height: 24px;
+      padding: 0;
+      border: none;
+      background: none;
+    }
+    #draw-controls .slider-row {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      margin-bottom: 6px;
+    }
+    #draw-controls .slider-row label {
+      flex: 1;
+    }
+    #draw-controls .slider-row span {
+      width: 32px;
+      text-align: right;
+    }
+    #draw-controls .slider-row input[type="range"] {
+      flex: 1;
+    }
+    body.light-mode #draw-controls {
+      background: rgba(255,255,255,0.95);
+      border: 1px solid #dadce0;
+      color: #202124;
+    }
 
     .note-icon {
       display: inline-block; cursor: pointer; position: absolute; margin: 0; padding: 4px; user-select: none;
@@ -375,6 +430,22 @@
         <div id="loading-text">Cargando…</div>
       </div>
     </div>
+  </div>
+
+  <div id="draw-controls">
+    <div class="color-row">
+      <label>Línea<input type="color" id="line-color" value="#ff0000"></label>
+      <label>Llenar<input type="color" id="fill-color" value="#ff00ff"></label>
+      <label>Fondo<input type="color" id="background-color" value="#808080"></label>
+      <label>Carrera<input type="color" id="stroke-color" value="#ffff00"></label>
+      <label>Sombra<input type="color" id="shadow-color" value="#000000"></label>
+    </div>
+    <div class="slider-row"><label>Ancho del cepillo</label><input type="range" id="brush-width" min="1" max="100" value="2" step="1"><span id="brush-width-val">2</span></div>
+    <div class="slider-row"><label>Anchura del trazo</label><input type="range" id="stroke-width" min="1" max="100" value="1" step="1"><span id="stroke-width-val">1</span></div>
+    <div class="slider-row"><label>Ancho de sombra</label><input type="range" id="shadow-width" min="0" max="50" value="0" step="1"><span id="shadow-width-val">0</span></div>
+    <div class="slider-row"><label>Desplazamiento de</label><input type="range" id="shadow-offset" min="0" max="50" value="0" step="1"><span id="shadow-offset-val">0</span></div>
+    <div class="slider-row"><label>Opacidad del</label><input type="range" id="line-opacity" min="0" max="1" value="1" step="0.01"><span id="line-opacity-val">1</span></div>
+    <div class="slider-row"><label>Opacidad de forma</label><input type="range" id="shape-opacity" min="0" max="1" value="0.2" step="0.01"><span id="shape-opacity-val">0.2</span></div>
   </div>
 
   <div id="permission-modal" class="permission-modal hidden">
@@ -580,6 +651,50 @@
       // Dibujo libre
       let drawMode = false;
       let isDrawing = false;
+      const drawControls = document.getElementById('draw-controls');
+      const lineColorInput = document.getElementById('line-color');
+      const fillColorInput = document.getElementById('fill-color');
+      const backgroundColorInput = document.getElementById('background-color');
+      const strokeColorInput = document.getElementById('stroke-color');
+      const shadowColorInput = document.getElementById('shadow-color');
+      const brushWidthInput = document.getElementById('brush-width');
+      const strokeWidthInput = document.getElementById('stroke-width');
+      const shadowWidthInput = document.getElementById('shadow-width');
+      const shadowOffsetInput = document.getElementById('shadow-offset');
+      const lineOpacityInput = document.getElementById('line-opacity');
+      const shapeOpacityInput = document.getElementById('shape-opacity');
+      const brushWidthVal = document.getElementById('brush-width-val');
+      const strokeWidthVal = document.getElementById('stroke-width-val');
+      const shadowWidthVal = document.getElementById('shadow-width-val');
+      const shadowOffsetVal = document.getElementById('shadow-offset-val');
+      const lineOpacityVal = document.getElementById('line-opacity-val');
+      const shapeOpacityVal = document.getElementById('shape-opacity-val');
+
+      const drawSettings = {
+        lineColor: lineColorInput.value,
+        fillColor: fillColorInput.value,
+        backgroundColor: backgroundColorInput.value,
+        strokeColor: strokeColorInput.value,
+        shadowColor: shadowColorInput.value,
+        brushWidth: parseFloat(brushWidthInput.value),
+        strokeWidth: parseFloat(strokeWidthInput.value),
+        shadowBlur: parseFloat(shadowWidthInput.value),
+        shadowOffset: parseFloat(shadowOffsetInput.value),
+        lineOpacity: parseFloat(lineOpacityInput.value),
+        shapeOpacity: parseFloat(shapeOpacityInput.value)
+      };
+
+      lineColorInput.addEventListener('input', e => drawSettings.lineColor = e.target.value);
+      fillColorInput.addEventListener('input', e => drawSettings.fillColor = e.target.value);
+      backgroundColorInput.addEventListener('input', e => drawSettings.backgroundColor = e.target.value);
+      strokeColorInput.addEventListener('input', e => drawSettings.strokeColor = e.target.value);
+      shadowColorInput.addEventListener('input', e => drawSettings.shadowColor = e.target.value);
+      brushWidthInput.addEventListener('input', e => { drawSettings.brushWidth = parseFloat(e.target.value); brushWidthVal.textContent = e.target.value; });
+      strokeWidthInput.addEventListener('input', e => { drawSettings.strokeWidth = parseFloat(e.target.value); strokeWidthVal.textContent = e.target.value; });
+      shadowWidthInput.addEventListener('input', e => { drawSettings.shadowBlur = parseFloat(e.target.value); shadowWidthVal.textContent = e.target.value; });
+      shadowOffsetInput.addEventListener('input', e => { drawSettings.shadowOffset = parseFloat(e.target.value); shadowOffsetVal.textContent = e.target.value; });
+      lineOpacityInput.addEventListener('input', e => { drawSettings.lineOpacity = parseFloat(e.target.value); lineOpacityVal.textContent = parseFloat(e.target.value).toFixed(2); });
+      shapeOpacityInput.addEventListener('input', e => { drawSettings.shapeOpacity = parseFloat(e.target.value); shapeOpacityVal.textContent = parseFloat(e.target.value).toFixed(2); });
 
       const PROMPT_FILE = 'prompts.json';
       const USER_PROMPTS = {
@@ -2088,6 +2203,7 @@
         const canvases = document.querySelectorAll('.draw-canvas');
         canvases.forEach(c => c.style.pointerEvents = drawMode ? 'auto' : 'none');
         drawIndicator.classList.toggle('active', drawMode);
+        drawControls.classList.toggle('active', drawMode);
       }
 
       function saveDrawing(canvas) {
@@ -2119,9 +2235,14 @@
         isDrawing = true;
         const canvas = e.target;
         const ctx = canvas.getContext('2d');
-        ctx.strokeStyle = '#ff0000';
-        ctx.lineWidth = 2;
+        ctx.strokeStyle = drawSettings.lineColor;
+        ctx.lineWidth = drawSettings.brushWidth;
         ctx.lineCap = 'round';
+        ctx.globalAlpha = drawSettings.lineOpacity;
+        ctx.shadowColor = drawSettings.shadowColor;
+        ctx.shadowBlur = drawSettings.shadowBlur;
+        ctx.shadowOffsetX = drawSettings.shadowOffset;
+        ctx.shadowOffsetY = drawSettings.shadowOffset;
         ctx.beginPath();
         ctx.moveTo(e.offsetX, e.offsetY);
         canvas._ctx = ctx;
@@ -2140,6 +2261,10 @@
         const canvas = e.target;
         const ctx = canvas._ctx;
         ctx.closePath();
+        ctx.globalAlpha = 1;
+        ctx.shadowBlur = 0;
+        ctx.shadowOffsetX = 0;
+        ctx.shadowOffsetY = 0;
         isDrawing = false;
         saveDrawing(canvas);
       }

--- a/public/visor/index.html
+++ b/public/visor/index.html
@@ -173,6 +173,22 @@
     }
     @keyframes spin { to { transform: rotate(360deg); } }
 
+    #draw-indicator {
+      position: fixed;
+      top: 10px;
+      right: 10px;
+      width: 24px;
+      height: 24px;
+      border-radius: 50%;
+      background: rgba(255,0,0,0.8);
+      border: 2px solid #fff;
+      z-index: 1100;
+      pointer-events: none;
+      display: none;
+    }
+    #draw-indicator.active { display: block; }
+    .draw-canvas { position: absolute; top: 0; left: 0; z-index: 800; }
+
     .note-icon {
       display: inline-block; cursor: pointer; position: absolute; margin: 0; padding: 4px; user-select: none;
       z-index: 900; font-size: 20px; background: rgba(255,255,255,0.95); border-radius: 50%;
@@ -549,6 +565,10 @@
       const closePdfModalBtn = document.getElementById('close-pdf-modal');
       const pdfModalBody = document.getElementById('pdf-modal-body');
 
+      const drawIndicator = document.createElement('div');
+      drawIndicator.id = 'draw-indicator';
+      document.body.appendChild(drawIndicator);
+
       let captureMode = false;
       let captureCategory = null; // 'teo' | 'practica'
       let pendingStart = null; // { pageNum, xp, yp, layer }
@@ -556,6 +576,10 @@
 
       let theoryHandle = null;
       let practiceHandle = null;
+
+      // Dibujo libre
+      let drawMode = false;
+      let isDrawing = false;
 
       const PROMPT_FILE = 'prompts.json';
       const USER_PROMPTS = {
@@ -794,6 +818,8 @@
           backBtn.disabled = false;
           fileInfo.textContent = filename;
           currentPdfName = filename;
+          drawMode = false;
+          updateDrawMode();
 
           const loadingTask = pdfjsLib.getDocument(url);
           pdfDoc = await loadingTask.promise;
@@ -854,6 +880,19 @@
           textLayer.style.width = w + 'px';
           textLayer.style.height = h + 'px';
           wrapper.appendChild(textLayer);
+
+          const drawCanvas = document.createElement('canvas');
+          drawCanvas.className = 'draw-canvas';
+          drawCanvas.width = w;
+          drawCanvas.height = h;
+          drawCanvas.dataset.page = String(pageNum);
+          drawCanvas.style.pointerEvents = 'none';
+          drawCanvas.style.touchAction = 'none';
+          drawCanvas.addEventListener('pointerdown', startDraw);
+          drawCanvas.addEventListener('pointermove', drawMove);
+          drawCanvas.addEventListener('pointerup', endDraw);
+          drawCanvas.addEventListener('pointerleave', endDraw);
+          wrapper.appendChild(drawCanvas);
 
           const layer = document.createElement('div');
           layer.className = 'anno-layer';
@@ -916,6 +955,7 @@
           pageStates.set(pageNum, state);
           observer.observe(wrapper);
         }
+        loadDrawingsFromStorage();
       }
 
       function clearContainer() {
@@ -1196,6 +1236,13 @@
           activeElement.tagName === 'INPUT' ||
           activeElement.classList.contains('mq-editable-field')
         );
+
+        if (!isEditing && !e.ctrlKey && !e.altKey && e.key.toLowerCase() === 'l') {
+          e.preventDefault();
+          drawMode = !drawMode;
+          updateDrawMode();
+          return;
+        }
 
         // Bloquear navegación si overlay visible
         if (loadingOverlay && !loadingOverlay.classList.contains('hidden')) {
@@ -2034,6 +2081,67 @@
         await writable.close();
         const file = new File([blob], pdfName, { type: 'application/pdf' });
         return { handle: fileHandle, file, blob };
+      }
+
+      // --- Dibujo libre ---
+      function updateDrawMode() {
+        const canvases = document.querySelectorAll('.draw-canvas');
+        canvases.forEach(c => c.style.pointerEvents = drawMode ? 'auto' : 'none');
+        drawIndicator.classList.toggle('active', drawMode);
+      }
+
+      function saveDrawing(canvas) {
+        if (!currentPdfName) return;
+        try {
+          localStorage.setItem(`drawing-${currentPdfName}-page${canvas.dataset.page}`, canvas.toDataURL());
+        } catch (e) {}
+      }
+
+      function loadDrawingsFromStorage() {
+        if (!currentPdfName) return;
+        let found = false;
+        document.querySelectorAll('.draw-canvas').forEach(canvas => {
+          const data = localStorage.getItem(`drawing-${currentPdfName}-page${canvas.dataset.page}`);
+          if (data) {
+            const ctx = canvas.getContext('2d');
+            const img = new Image();
+            img.onload = () => ctx.drawImage(img,0,0);
+            img.src = data;
+            found = true;
+          }
+        });
+        drawMode = found;
+        updateDrawMode();
+      }
+
+      function startDraw(e) {
+        if (!drawMode) return;
+        isDrawing = true;
+        const canvas = e.target;
+        const ctx = canvas.getContext('2d');
+        ctx.strokeStyle = '#ff0000';
+        ctx.lineWidth = 2;
+        ctx.lineCap = 'round';
+        ctx.beginPath();
+        ctx.moveTo(e.offsetX, e.offsetY);
+        canvas._ctx = ctx;
+      }
+
+      function drawMove(e) {
+        if (!isDrawing) return;
+        const canvas = e.target;
+        const ctx = canvas._ctx;
+        ctx.lineTo(e.offsetX, e.offsetY);
+        ctx.stroke();
+      }
+
+      function endDraw(e) {
+        if (!isDrawing) return;
+        const canvas = e.target;
+        const ctx = canvas._ctx;
+        ctx.closePath();
+        isDrawing = false;
+        saveDrawing(canvas);
       }
 
       // cargar pdf inicial si viene por query


### PR DESCRIPTION
## Summary
- allow toggling a freehand drawing mode with the `l` key
- render per-page canvases and persist drawings in localStorage
- show a circle indicator when drawing mode is active

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (interactive ESLint prompt, no config)

------
https://chatgpt.com/codex/tasks/task_e_68b21ba08598833083148e4b71d4c465