### PR TITLE
Fix pencil tool to draw continuous stroke

### DIFF
--- a/public/visor/index.html
+++ b/public/visor/index.html
@@ -2265,8 +2265,6 @@
         const ctx = canvas._ctx;
         ctx.lineTo(e.offsetX, e.offsetY);
         ctx.stroke();
-        ctx.beginPath();
-        ctx.moveTo(e.offsetX, e.offsetY);
       }
 
       function endDraw(e) {
@@ -2275,7 +2273,7 @@
         const ctx = canvas._ctx;
         ctx.lineTo(e.offsetX, e.offsetY);
         ctx.stroke();
-        ctx.beginPath();
+        ctx.closePath();
         isDrawing = false;
         saveDrawing(canvas);
       }


### PR DESCRIPTION
## Summary
- ensure pencil lines draw continuously without breaking into segments

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: prompts for ESLint configuration)


------
https://chatgpt.com/codex/tasks/task_e_68b2ff2b6a988330a0e5ad27c6f64c6d