### PR TITLE
feat: enable area focus overlay and hide drawing settings

### DIFF
--- a/public/visor/index.html
+++ b/public/visor/index.html
@@ -228,6 +228,26 @@
     }
     #draw-toolbar input[type="range"] { flex: 1; }
 
+    #focus-overlay {
+      position: fixed;
+      inset: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: rgba(0,0,0,0.9);
+      z-index: 2000;
+    }
+    #focus-overlay canvas {
+      max-width: calc(100% - 40px);
+      max-height: calc(100% - 40px);
+      border: 2px solid #fff;
+    }
+    body.light-mode #focus-overlay { background: rgba(255,255,255,0.95); }
+    body.light-mode #focus-overlay canvas { border-color: #000; }
+    body:not(.light-mode) #focus-overlay canvas {
+      filter: invert(1) hue-rotate(180deg);
+    }
+
     .note-icon {
       display: inline-block; cursor: pointer; position: absolute; margin: 0; padding: 4px; user-select: none;
       z-index: 900; font-size: 20px; background: rgba(255,255,255,0.95); border-radius: 50%;
@@ -612,6 +632,28 @@
       let captureCategory = null; // 'teo' | 'practica'
       let pendingStart = null; // { pageNum, xp, yp, layer }
       let selections = []; // { id, pageNum, xp1, yp1, xp2, yp2, elem }
+
+      let focusMode = false;
+      let focusStart = null;
+      let focusPreview = null;
+
+      function updateFocusPreview(e) {
+        if (!focusMode || !focusStart || !focusPreview) return;
+        const layer = focusStart.layer;
+        const rect = layer.getBoundingClientRect();
+        const x = Math.max(0, Math.min(e.clientX - rect.left, rect.width));
+        const y = Math.max(0, Math.min(e.clientY - rect.top, rect.height));
+        const xp = x / rect.width;
+        const yp = y / rect.height;
+        const x1 = Math.min(focusStart.xp, xp) * rect.width;
+        const y1 = Math.min(focusStart.yp, yp) * rect.height;
+        const x2 = Math.max(focusStart.xp, xp) * rect.width;
+        const y2 = Math.max(focusStart.yp, yp) * rect.height;
+        focusPreview.style.left = x1 + 'px';
+        focusPreview.style.top = y1 + 'px';
+        focusPreview.style.width = Math.max(1, x2 - x1) + 'px';
+        focusPreview.style.height = Math.max(1, y2 - y1) + 'px';
+      }
 
       let theoryHandle = null;
       let practiceHandle = null;
@@ -1048,6 +1090,40 @@
               return;
             }
 
+            if (focusMode) {
+              e.preventDefault();
+              e.stopPropagation();
+              const lx = x; const ly = y;
+              const xp = lx / layer.offsetWidth;
+              const yp = ly / layer.offsetHeight;
+              if (!focusStart) {
+                focusStart = { pageNum, xp, yp, layer };
+                focusPreview = document.createElement('div');
+                focusPreview.className = 'selection-rect';
+                layer.appendChild(focusPreview);
+                document.addEventListener('mousemove', updateFocusPreview);
+                showNavIndicator('Punto inicial marcado');
+                return;
+              }
+              if (focusStart.pageNum !== pageNum) {
+                focusStart = { pageNum, xp, yp, layer };
+                focusPreview?.remove();
+                focusPreview = document.createElement('div');
+                focusPreview.className = 'selection-rect';
+                layer.appendChild(focusPreview);
+                document.addEventListener('mousemove', updateFocusPreview);
+                showToast('Inicio restablecido en esta página', 'info');
+                return;
+              }
+              focusPreview?.remove();
+              focusPreview = null;
+              document.removeEventListener('mousemove', updateFocusPreview);
+              focusArea(pageNum, focusStart.xp, focusStart.yp, xp, yp);
+              focusStart = null;
+              focusMode = false;
+              return;
+            }
+
             if (captureMode) {
               e.preventDefault();
               e.stopPropagation();
@@ -1420,6 +1496,23 @@
           return;
         }
 
+        if (e.key.toLowerCase() === 'o' && !e.repeat && !e.ctrlKey && !e.altKey && !isEditing) {
+          e.preventDefault();
+          if (!pdfDoc) return;
+          if (captureMode) { showToast('Finaliza la captura (Ctrl+I) antes de enfocar', 'info'); return; }
+          focusMode = !focusMode;
+          focusStart = null;
+          focusPreview?.remove();
+          focusPreview = null;
+          document.removeEventListener('mousemove', updateFocusPreview);
+          if (focusMode) {
+            showNavIndicator('Haz dos clics para enfocar');
+          } else {
+            showToast('Enfoque cancelado', 'info');
+          }
+          return;
+        }
+
         if (e.key.toLowerCase() === 'f' && !e.repeat && !e.ctrlKey && !isEditing) {
           e.preventDefault(); if (pdfDoc) toggleFullscreen();
         }
@@ -1478,6 +1571,16 @@
             exitCaptureMode(true);
             showToast('Captura cancelada', 'info');
           }
+          if (focusMode) {
+            focusMode = false;
+            focusStart = null;
+            focusPreview?.remove();
+            focusPreview = null;
+            document.removeEventListener('mousemove', updateFocusPreview);
+            showToast('Enfoque cancelado', 'info');
+          }
+          const fo = document.getElementById('focus-overlay');
+          if (fo) fo.remove();
           creatingNote = false;
           document.body.classList.remove('creating-note');
           if (isFullscreen) toggleFullscreen();
@@ -1999,6 +2102,39 @@
         showNavIndicator('Selección añadida (' + selections.length + ')');
       }
 
+      async function focusArea(pageNum, xp1, yp1, xp2, yp2) {
+        const page = await pdfDoc.getPage(pageNum);
+        const widthFrac = Math.abs(xp2 - xp1);
+        const heightFrac = Math.abs(yp2 - yp1);
+        if (widthFrac === 0 || heightFrac === 0) return;
+
+        const maxW = window.innerWidth - 40;
+        const maxH = window.innerHeight - 40;
+        const ratio = window.devicePixelRatio || 1;
+        const scale = Math.min((maxW * ratio) / (baseWidth * widthFrac), (maxH * ratio) / (baseHeight * heightFrac));
+        const viewport = page.getViewport({ scale });
+        const x1 = Math.min(xp1, xp2) * viewport.width;
+        const y1 = Math.min(yp1, yp2) * viewport.height;
+        const w = widthFrac * viewport.width;
+        const h = heightFrac * viewport.height;
+
+        const canvas = document.createElement('canvas');
+        canvas.width = Math.max(1, Math.round(w));
+        canvas.height = Math.max(1, Math.round(h));
+        const ctx = canvas.getContext('2d');
+        ctx.translate(-x1, -y1);
+        await page.render({ canvasContext: ctx, viewport }).promise;
+
+        const overlay = document.createElement('div');
+        overlay.id = 'focus-overlay';
+        const displayScale = Math.min(maxW / (canvas.width / ratio), maxH / (canvas.height / ratio));
+        canvas.style.width = (canvas.width / ratio * displayScale) + 'px';
+        canvas.style.height = (canvas.height / ratio * displayScale) + 'px';
+        overlay.appendChild(canvas);
+        overlay.addEventListener('click', () => overlay.remove());
+        document.body.appendChild(overlay);
+      }
+
       function sanitizeName(name) {
         return (name || 'documento').replace(/[^a-zA-Z0-9._-]/g, '_');
       }
@@ -2246,6 +2382,7 @@
         });
         drawMode = true;
         updateDrawMode();
+        drawToolbar.classList.remove('active');
       }
 
       function startDraw(e) {


### PR DESCRIPTION
## Summary
- hide drawing toolbar on load so settings aren't shown when opening PDFs
- add focus mode on key `o` to zoom a selected area with themed border overlay
- render focused area from PDF at high resolution and preview selection live

## Testing
- `npm test` *(fails: Missing script "test")*
- `DATABASE_URL=file:./dev.db npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b34e2dd558833083284427a6ca7f9a