### PR TITLE
Optimize PDF viewer rendering

### DIFF
--- a/public/visor/index.html
+++ b/public/visor/index.html
@@ -110,7 +110,6 @@
     body:not(.light-mode) .page-wrapper canvas {
       filter: invert(1) hue-rotate(180deg);
     }
-    body:not(.light-mode) .textLayer,
     body:not(.light-mode) .annotationLayer {
       filter: invert(1) hue-rotate(180deg);
     }
@@ -885,8 +884,6 @@
 
           state.wrapper.style.width = viewport.width + 'px';
           state.wrapper.style.height = viewport.height + 'px';
-          state.textLayer.style.width = viewport.width + 'px';
-          state.textLayer.style.height = viewport.height + 'px';
           state.layer.style.width = viewport.width + 'px';
           state.layer.style.height = viewport.height + 'px';
 
@@ -900,15 +897,6 @@
           ctx.setTransform(ratio, 0, 0, ratio, 0, 0);
 
           await page.render({ canvasContext: ctx, viewport }).promise;
-
-          state.textLayer.innerHTML = '';
-          const textContent = await page.getTextContent();
-          await pdfjsLib.renderTextLayer({
-            textContent,
-            container: state.textLayer,
-            viewport,
-            textDivs: []
-          }).promise;
 
           state.renderedScale = scale;
           repositionNotesForLayer(state.layer);
@@ -936,7 +924,6 @@
           if (far && state.canvas.width > 0) {
             state.canvas.width = 0;
             state.canvas.height = 0;
-            state.textLayer.innerHTML = '';
             state.renderedScale = 0;
           }
         }
@@ -1044,12 +1031,6 @@
           canvas.width = 0; canvas.height = 0;
           wrapper.appendChild(canvas);
 
-          const textLayer = document.createElement('div');
-          textLayer.className = 'textLayer';
-          textLayer.style.width = w + 'px';
-          textLayer.style.height = h + 'px';
-          wrapper.appendChild(textLayer);
-
           const drawCanvas = document.createElement('canvas');
           drawCanvas.className = 'draw-canvas';
           drawCanvas.width = w;
@@ -1154,7 +1135,7 @@
 
           container.appendChild(wrapper);
 
-          const state = { wrapper, canvas, textLayer, layer, renderedScale: 0, rendering: false, width: w, height: h };
+          const state = { wrapper, canvas, layer, renderedScale: 0, rendering: false, width: w, height: h };
           pageStates.set(pageNum, state);
           observer.observe(wrapper);
         }
@@ -1185,20 +1166,12 @@
       }
 
       function prepareInitialReveal() {
-        const sample = pageStates.get(1);
-        const h = sample ? sample.wrapper.getBoundingClientRect().height : (baseHeight * currentZoom * 1.5);
-        const pagesNeeded = Math.min(
-          totalPages,
-          Math.max(1, Math.ceil(container.clientHeight / Math.max(1, h)) + 1)
-        );
-
-        initialRevealSet = new Set();
-        for (let i = 1; i <= pagesNeeded; i++) initialRevealSet.add(i);
-        initialRevealNeeded = initialRevealSet.size;
+        initialRevealSet = new Set([1]);
+        initialRevealNeeded = 1;
         initialRevealCount = 0;
         initialRevealPending = true;
 
-        for (const pn of initialRevealSet) scheduleRender(pn);
+        scheduleRender(1);
         showOverlay('Preparando vista…');
       }
 
@@ -1217,9 +1190,9 @@
         const scrollRatio = beforeHeight > 0 ? beforeTop / beforeHeight : 0;
 
         const scale = currentZoom * 1.5;
-        for (const [pn, st] of pageStates.entries()) {
-          const w = baseWidth * scale;
-          const h = baseHeight * scale;
+        const w = baseWidth * scale;
+        const h = baseHeight * scale;
+        for (const [, st] of pageStates.entries()) {
           st.wrapper.style.width = w + 'px';
           st.wrapper.style.height = h + 'px';
           st.layer.style.width = w + 'px';
@@ -1230,7 +1203,13 @@
         repositionAllNotes();
         repositionAllSelections();
 
-        for (const pn of visibleSet) scheduleRender(pn);
+        const toRender = new Set();
+        visibleSet.forEach(pn => {
+          toRender.add(pn);
+          if (pageStates.has(pn + 1)) toRender.add(pn + 1);
+          if (pageStates.has(pn - 1)) toRender.add(pn - 1);
+        });
+        toRender.forEach(pn => scheduleRender(pn));
 
         requestAnimationFrame(() => {
           const afterHeight = container.scrollHeight;


### PR DESCRIPTION
## Summary
- Lazy render: only load first PDF page initially and queue others on demand
- Remove text layer to avoid text selection and reduce render cost
- Adjust zoom to rerender visible pages and neighbors for smoother navigation

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: requires interactive ESLint setup)


------
https://chatgpt.com/codex/tasks/task_e_68b43c8d68608330ae02d38885993519