### PR TITLE
chore: remove pdf text layer

### DIFF
--- a/public/visor/index.html
+++ b/public/visor/index.html
@@ -110,7 +110,6 @@
     body:not(.light-mode) .page-wrapper canvas {
       filter: invert(1) hue-rotate(180deg);
     }
-    body:not(.light-mode) .textLayer,
     body:not(.light-mode) .annotationLayer {
       filter: invert(1) hue-rotate(180deg);
     }
@@ -885,8 +884,6 @@
 
           state.wrapper.style.width = viewport.width + 'px';
           state.wrapper.style.height = viewport.height + 'px';
-          state.textLayer.style.width = viewport.width + 'px';
-          state.textLayer.style.height = viewport.height + 'px';
           state.layer.style.width = viewport.width + 'px';
           state.layer.style.height = viewport.height + 'px';
 
@@ -900,15 +897,6 @@
           ctx.setTransform(ratio, 0, 0, ratio, 0, 0);
 
           await page.render({ canvasContext: ctx, viewport }).promise;
-
-          state.textLayer.innerHTML = '';
-          const textContent = await page.getTextContent();
-          await pdfjsLib.renderTextLayer({
-            textContent,
-            container: state.textLayer,
-            viewport,
-            textDivs: []
-          }).promise;
 
           state.renderedScale = scale;
           repositionNotesForLayer(state.layer);
@@ -936,7 +924,6 @@
           if (far && state.canvas.width > 0) {
             state.canvas.width = 0;
             state.canvas.height = 0;
-            state.textLayer.innerHTML = '';
             state.renderedScale = 0;
           }
         }
@@ -1044,11 +1031,6 @@
           canvas.width = 0; canvas.height = 0;
           wrapper.appendChild(canvas);
 
-          const textLayer = document.createElement('div');
-          textLayer.className = 'textLayer';
-          textLayer.style.width = w + 'px';
-          textLayer.style.height = h + 'px';
-          wrapper.appendChild(textLayer);
 
           const drawCanvas = document.createElement('canvas');
           drawCanvas.className = 'draw-canvas';
@@ -1154,7 +1136,7 @@
 
           container.appendChild(wrapper);
 
-          const state = { wrapper, canvas, textLayer, layer, renderedScale: 0, rendering: false, width: w, height: h };
+          const state = { wrapper, canvas, layer, renderedScale: 0, rendering: false, width: w, height: h };
           pageStates.set(pageNum, state);
           observer.observe(wrapper);
         }


### PR DESCRIPTION
## Summary
- remove PDF text layer rendering and styling to avoid text selection

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b43c8d68608330ae02d38885993519