### PR TITLE
Renderizado nítido al hacer zoom en visor PDF

### DIFF
--- a/public/visor/index.html
+++ b/public/visor/index.html
@@ -527,16 +527,44 @@
       // ========================================
       const container = document.getElementById('pdf-container');
       let zoomLevel = 1;
+
       function applyZoom() {
-        container.style.zoom = String(zoomLevel);
+        const scale = BASE_SCALE * zoomLevel;
+        const current = getCurrentPage();
+        for (const [pageNum, state] of pageStates.entries()) {
+          const w = baseWidth * scale;
+          const h = baseHeight * scale;
+          state.wrapper.style.width = w + 'px';
+          state.wrapper.style.height = h + 'px';
+          state.layer.style.width = w + 'px';
+          state.layer.style.height = h + 'px';
+          if (state.canvas) {
+            state.canvas.style.width = w + 'px';
+            state.canvas.style.height = h + 'px';
+          }
+          const drawCanvas = state.wrapper.querySelector('.draw-canvas');
+          if (drawCanvas) {
+            drawCanvas.style.width = w + 'px';
+            drawCanvas.style.height = h + 'px';
+            if (pageNum === current) {
+              drawCanvas.width = w;
+              drawCanvas.height = h;
+            }
+          }
+          if (pageNum === current) {
+            state.renderedScale = 0;
+            scheduleRender(pageNum);
+          }
+        }
       }
-      applyZoom();
+
       window.addEventListener('message', (e) => {
         if (e.data && e.data.type === 'resetZoom') {
           zoomLevel = 1;
           applyZoom();
         }
       });
+
       container.addEventListener('wheel', (e) => {
         if (e.ctrlKey) {
           e.preventDefault();
@@ -546,6 +574,7 @@
           applyZoom();
         }
       }, { passive: false });
+
       document.addEventListener('keydown', (e) => {
         if (!e.ctrlKey) return;
         if (e.key === '+' || e.key === '=') {
@@ -576,9 +605,14 @@
       let loadingText = document.getElementById('loading-text');
 
       container.addEventListener('scroll', () => {
-        if (currentPdfName) {
-          const p = getCurrentPage();
-          localStorage.setItem('lastPage-' + currentPdfName, String(p));
+        if (!currentPdfName) return;
+        const p = getCurrentPage();
+        currentPage = p;
+        localStorage.setItem('lastPage-' + currentPdfName, String(p));
+        const state = pageStates.get(p);
+        const targetScale = BASE_SCALE * zoomLevel;
+        if (state && Math.abs((state.renderedScale || 0) - targetScale) > 0.001) {
+          scheduleRender(p);
         }
       });
 
@@ -872,7 +906,7 @@
       function scheduleRender(pageNum) {
         const state = pageStates.get(pageNum);
         if (!state) return;
-        const targetScale = BASE_SCALE;
+        const targetScale = BASE_SCALE * zoomLevel;
         if (state.rendering) return;
         if (Math.abs((state.renderedScale || 0) - targetScale) < 0.001 && state.canvas?.width) return;
         if (!renderQueue.includes(pageNum)) renderQueue.push(pageNum);
@@ -899,24 +933,31 @@
         try {
           state.rendering = true;
           const page = await pdfDoc.getPage(pageNum);
-          const scale = BASE_SCALE;
+          const scale = BASE_SCALE * zoomLevel;
           const viewport = page.getViewport({ scale });
 
           state.wrapper.style.width = viewport.width + 'px';
           state.wrapper.style.height = viewport.height + 'px';
           state.layer.style.width = viewport.width + 'px';
           state.layer.style.height = viewport.height + 'px';
-
-          const ratio = window.devicePixelRatio || 1;
-          state.canvas.width = Math.floor(viewport.width * ratio);
-          state.canvas.height = Math.floor(viewport.height * ratio);
           state.canvas.style.width = viewport.width + 'px';
           state.canvas.style.height = viewport.height + 'px';
 
-          const ctx = state.canvas.getContext('2d');
+          const ratio = window.devicePixelRatio || 1;
+          const offscreen = document.createElement('canvas');
+          offscreen.width = Math.floor(viewport.width * ratio);
+          offscreen.height = Math.floor(viewport.height * ratio);
+          const ctx = offscreen.getContext('2d');
           ctx.setTransform(ratio, 0, 0, ratio, 0, 0);
 
           await page.render({ canvasContext: ctx, viewport }).promise;
+
+          state.canvas.width = offscreen.width;
+          state.canvas.height = offscreen.height;
+          const mainCtx = state.canvas.getContext('2d');
+          mainCtx.setTransform(1, 0, 0, 1, 0, 0);
+          mainCtx.clearRect(0, 0, offscreen.width, offscreen.height);
+          mainCtx.drawImage(offscreen, 0, 0);
 
           state.renderedScale = scale;
           repositionNotesForLayer(state.layer);
@@ -1034,7 +1075,7 @@
 
       function buildPageSkeletons() {
         clearContainer();
-        const scale = BASE_SCALE;
+        const scale = BASE_SCALE * zoomLevel;
         for (let pageNum = 1; pageNum <= totalPages; pageNum++) {
           const wrapper = document.createElement('div');
           wrapper.className = 'page-wrapper';


### PR DESCRIPTION
## Summary
- Re-render de páginas PDF según el nivel de zoom para mantener calidad
- Uso de canvas fuera de pantalla para actualizar sin parpadeos
- Solo se renderiza la página activa al cambiar zoom; el resto se escala vía CSS hasta enfocarse

## Testing
- `npm test` (missing script)
- `npm run lint` (interactive prompt)

------
https://chatgpt.com/codex/tasks/task_e_68b44c21a790833084cbbdb1109d8ce1