### PR TITLE
fix: improve drawing handling

### DIFF
--- a/public/visor/index.html
+++ b/public/visor/index.html
@@ -177,7 +177,8 @@
       background: rgba(255,0,0,0.8);
       border: 2px solid #fff;
       z-index: 1100;
-      pointer-events: none;
+      cursor: pointer;
+      pointer-events: auto;
       display: none;
     }
     #draw-indicator.active { display: block; }
@@ -602,13 +603,13 @@
       let loadingText = document.getElementById('loading-text');
 
       container.addEventListener('scroll', () => {
-        if (currentPdfName) {
+        if (currentPdfKey) {
           const p = getCurrentPage();
           if (p !== currentPage) {
             currentPage = p;
             scheduleRender(p);
           }
-          localStorage.setItem('lastPage-' + currentPdfName, String(p));
+          localStorage.setItem('lastPage-' + currentPdfKey, String(p));
         }
       });
 
@@ -650,6 +651,7 @@
       // Persistencia de notas
       let directoryHandle = null;
       let currentPdfName = null;
+      let currentPdfKey = null;
       let saveTimeout = null;
       let db = null;
 
@@ -676,6 +678,11 @@
       const drawIndicator = document.createElement('div');
       drawIndicator.id = 'draw-indicator';
       document.body.appendChild(drawIndicator);
+
+      drawIndicator.addEventListener('click', () => {
+        if (!drawMode) return;
+        drawToolbar.classList.toggle('active');
+      });
 
       let captureMode = false;
       let captureCategory = null; // 'teo' | 'practica'
@@ -764,6 +771,7 @@
         <label>Opacidad del <input type="range" id="tool-opacity-line" min="0" max="1" step="0.01" value="1"></label>
         <label>Opacidad de forma <input type="range" id="tool-opacity-shape" min="0" max="1" step="0.01" value="1"></label>
         <button id="tool-erase-btn">Borrar</button>
+        <button id="tool-clear-all">Borrar todo</button>
       `;
       document.body.appendChild(drawToolbar);
 
@@ -774,6 +782,7 @@
       const shadowOffsetInput = drawToolbar.querySelector('#tool-shadow-offset');
       const opacityInput = drawToolbar.querySelector('#tool-opacity-line');
       const eraseBtn = drawToolbar.querySelector('#tool-erase-btn');
+      const clearAllBtn = drawToolbar.querySelector('#tool-clear-all');
 
       lineColorInput.addEventListener('input', e => { brushColor = e.target.value; saveBrushSettings(); });
       brushWidthInput.addEventListener('input', e => { brushWidth = parseInt(e.target.value, 10); saveBrushSettings(); });
@@ -785,6 +794,7 @@
         eraseMode = !eraseMode;
         eraseBtn.textContent = eraseMode ? 'Dibujar' : 'Borrar';
       });
+      clearAllBtn.addEventListener('click', clearAllDrawings);
 
       function applyBrushSettings() {
         lineColorInput.value = brushColor;
@@ -1018,7 +1028,7 @@
       // ========================================
       // CARGA DE PDF
       // ========================================
-      async function loadPdf(url, filename) {
+      async function loadPdf(url, filename, uniqueKey = '') {
         try {
           showOverlay('Cargando PDF…');
           clearContainer();
@@ -1031,6 +1041,7 @@
           backBtn.disabled = false;
           fileInfo.textContent = filename;
           currentPdfName = filename;
+          currentPdfKey = uniqueKey ? `${filename}-${uniqueKey}` : filename;
           drawMode = true;
           currentCanvas = null;
           updateDrawMode();
@@ -1051,7 +1062,7 @@
           buildPageSkeletons();
           prepareInitialReveal();
           const saved = parseInt(
-            localStorage.getItem('lastPage-' + filename) || '1',
+            localStorage.getItem('lastPage-' + currentPdfKey) || '1',
           );
           setTimeout(() => scrollToPage(saved), 0);
           pendingAfterLoadGoTo = null;
@@ -1066,6 +1077,7 @@
           backBtn.disabled = true;
           fileInfo.textContent = 'Visor PDF';
           currentPdfName = null;
+          currentPdfKey = null;
           hideOverlay();
         }
       }
@@ -1293,6 +1305,7 @@
         currentPage = 1;
         totalPages = 0;
         currentPdfName = null;
+        currentPdfKey = null;
         hideOverlay();
         if (directoryHandle) updateFileStatus('saved', 'Carpeta configurada');
         else updateFileStatus('no-access', 'Sin acceso');
@@ -1313,7 +1326,7 @@
             const url = URL.createObjectURL(file);
             currentObjectUrl = url;
             currentPdfIndex = -1;
-            loadPdf(url, file.name);
+            loadPdf(url, file.name, file.lastModified);
           } else {
             showToast('Por favor selecciona un archivo PDF', 'error');
           }
@@ -1326,7 +1339,7 @@
             const url = URL.createObjectURL(file);
             currentObjectUrl = url;
             currentPdfIndex = -1;
-            loadPdf(url, file.name);
+            loadPdf(url, file.name, file.lastModified);
           } else {
             showToast('Por favor selecciona un archivo PDF', 'error');
           }
@@ -1383,12 +1396,15 @@
         if (index < 0 || index >= pdfEntries.length) return;
         try {
           let arrayBuffer;
+          let uniqueKey;
           const entry = pdfEntries[index];
           if (entry.handle) {
             const file = await entry.handle.getFile();
             arrayBuffer = await file.arrayBuffer();
+            uniqueKey = file.lastModified;
           } else if (entry.file) {
             arrayBuffer = await entry.file.arrayBuffer();
+            uniqueKey = entry.file.lastModified;
           } else {
             throw new Error('Entrada inválida');
           }
@@ -1397,7 +1413,7 @@
           const url = URL.createObjectURL(blob);
           currentObjectUrl = url;
           pendingAfterLoadGoTo = after;
-          await loadPdf(url, entry.name);
+          await loadPdf(url, entry.name, uniqueKey);
           currentPdfIndex = index;
           showNavIndicator(`PDF ${index + 1}/${pdfEntries.length}: ${entry.name}`);
         } catch (e) {
@@ -2338,21 +2354,21 @@
         const canvases = document.querySelectorAll('.draw-canvas');
         canvases.forEach(c => c.style.pointerEvents = drawMode ? 'auto' : 'none');
         drawIndicator.classList.toggle('active', drawMode);
-        drawToolbar.classList.toggle('active', drawMode);
+        if (!drawMode) drawToolbar.classList.remove('active');
       }
 
       function saveDrawing(canvas) {
-        if (!currentPdfName) return;
+        if (!currentPdfKey) return;
         try {
-          localStorage.setItem(`drawing-${currentPdfName}-page${canvas.dataset.page}`, canvas.toDataURL());
+          localStorage.setItem(`drawing-${currentPdfKey}-page${canvas.dataset.page}`, canvas.toDataURL());
         } catch (e) {}
       }
 
       function loadDrawingsFromStorage() {
-        if (!currentPdfName) return;
+        if (!currentPdfKey) return;
         let found = false;
         document.querySelectorAll('.draw-canvas').forEach(canvas => {
-          const data = localStorage.getItem(`drawing-${currentPdfName}-page${canvas.dataset.page}`);
+          const data = localStorage.getItem(`drawing-${currentPdfKey}-page${canvas.dataset.page}`);
           if (data) {
             const ctx = canvas.getContext('2d');
             const img = new Image();
@@ -2364,6 +2380,16 @@
         drawMode = true;
         updateDrawMode();
         drawToolbar.classList.remove('active');
+      }
+
+      function clearAllDrawings() {
+        if (!currentPdfKey) return;
+        document.querySelectorAll('.draw-canvas').forEach(canvas => {
+          const ctx = canvas.getContext('2d');
+          ctx.clearRect(0, 0, canvas.width, canvas.height);
+          canvas._history = [];
+          localStorage.removeItem(`drawing-${currentPdfKey}-page${canvas.dataset.page}`);
+        });
       }
 
       function startDraw(e) {


### PR DESCRIPTION
## Summary
- avoid drawing persistence across PDFs with same name by using a unique key
- add **Borrar todo** button to clear drawings of current PDF
- only show drawing toolbar after clicking the draw icon

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (interactive ESLint setup prompt)


------
https://chatgpt.com/codex/tasks/task_e_68b598616a448330b441e667e59ab883