### PR TITLE
Improve viewer focus mode and layout

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -15,7 +15,7 @@ type PdfFile = {
 }
 
 export default function Home() {
-  const { setTheme } = useTheme()
+  const { theme, setTheme } = useTheme()
   const [started, setStarted] = useState(false)
   const [setupComplete, setSetupComplete] = useState(true)
   const [step, setStep] = useState(0)
@@ -490,6 +490,16 @@ useEffect(() => {
     return diff
   }
 
+  const toggleViewerFullscreen = () => {
+    viewerRef.current?.contentWindow?.postMessage({ type: 'toggleFullscreen' }, '*')
+  }
+
+  const toggleTheme = () => {
+    const next = theme === 'light' ? 'dark' : 'light'
+    setTheme(next)
+    viewerRef.current?.contentWindow?.postMessage({ type: 'toggleTheme' }, '*')
+  }
+
   const handleSelectFile = (pdf: PdfFile) => {
     const idx = queue.findIndex((f) => f.path === pdf.path)
     if (idx >= 0) {
@@ -794,6 +804,8 @@ useEffect(() => {
                   <span>
                     Días restantes: {currentPdf ? daysUntil(currentPdf) : ''}
                   </span>
+                  <button onClick={toggleViewerFullscreen}>[ ]</button>
+                  <button onClick={toggleTheme}>{theme === 'light' ? '🌞' : '🌙'}</button>
                   <button
                     onClick={() => {
                       setViewerOpen(false)
@@ -859,11 +871,6 @@ useEffect(() => {
               </div>
             )}
           </div>
-          {!viewerOpen && (
-            <div className="p-2 text-sm text-gray-500">
-              {currentPdf ? `Semana ${currentPdf.week} - ${currentPdf.subject}` : ''}
-            </div>
-          )}
         </section>
       </main>
     {/* Toast banner */}

--- a/public/visor/index.html
+++ b/public/visor/index.html
@@ -37,9 +37,9 @@
     }
 
     #app-header {
+      display: none;
       padding: 8px 16px;
       background: #323639;
-      display: flex;
       align-items: center;
       justify-content: space-between;
       border-bottom: 1px solid #5f6368;
@@ -69,7 +69,7 @@
 
 
     #drop-zone {
-      position: absolute; top: 56px; left: 0; right: 0; bottom: 0;
+      position: absolute; top: 0; left: 0; right: 0; bottom: 0;
       display: flex; flex-direction: column; align-items: center; justify-content: center;
       background: #525659; z-index: 100;
     }
@@ -88,7 +88,7 @@
     #file-input { display: none; }
 
     #pdf-container {
-      position: absolute; top: 56px; left: 0; right: 0; bottom: 0;
+      position: absolute; top: 0; left: 0; right: 0; bottom: 0;
       overflow-y: auto; overflow-x: auto; padding: 16px 0; background: #525659;
     }
     body.light-mode #pdf-container { background: #fff; }
@@ -545,8 +545,13 @@
           }
           const drawCanvas = state.wrapper.querySelector('.draw-canvas');
           if (drawCanvas) {
+            const data = drawCanvas.toDataURL();
             drawCanvas.width = w;
             drawCanvas.height = h;
+            const ctx = drawCanvas.getContext('2d');
+            const img = new Image();
+            img.onload = () => ctx.drawImage(img, 0, 0, w, h);
+            img.src = data;
           }
           if (pageNum === cur) {
             state.renderedScale = 0;
@@ -557,9 +562,14 @@
       }
 
       window.addEventListener('message', (e) => {
-        if (e.data && e.data.type === 'resetZoom') {
+        if (!e.data) return;
+        if (e.data.type === 'resetZoom') {
           zoomLevel = 1;
           applyZoom();
+        } else if (e.data.type === 'toggleFullscreen') {
+          toggleFullscreen();
+        } else if (e.data.type === 'toggleTheme') {
+          toggleTheme();
         }
       });
 
@@ -643,10 +653,11 @@
       let creatingNote = false;
       const MQ = MathQuill.getInterface(2);
 
-      themeToggleBtn.addEventListener('click', () => {
+      function toggleTheme() {
         document.body.classList.toggle('light-mode');
         themeToggleBtn.textContent = document.body.classList.contains('light-mode') ? '🌞' : '🌙';
-      });
+      }
+      themeToggleBtn.addEventListener('click', toggleTheme);
 
       // Persistencia de notas
       let directoryHandle = null;
@@ -1171,7 +1182,7 @@
               document.removeEventListener('mousemove', updateFocusPreview);
               focusArea(pageNum, focusStart.xp, focusStart.yp, xp, yp);
               focusStart = null;
-              focusMode = false;
+              showNavIndicator('Haz dos clics para enfocar');
               return;
             }
 


### PR DESCRIPTION
## Summary
- Preserve drawings when zooming and keep focus mode active until toggled off
- Move viewer controls to main bar and hide duplicate/bottom bars
- Add keyboard-driven fullscreen and theme toggles via parent messages

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68b5a4eeaa288330a7e344edfc1f4b5a