### PR TITLE
Improve PDF viewer zoom redraw and UI controls

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -37,6 +37,7 @@ export default function Home() {
   const [orders, setOrders] = useState<Record<string, string[]>>({})
   const [viewerOpen, setViewerOpen] = useState(false)
   const [pdfFullscreen, setPdfFullscreen] = useState(false)
+  const [viewerLight, setViewerLight] = useState(false)
   const [dragCategory, setDragCategory] = useState<'theory' | 'practice' | null>(null)
   const [showSettings, setShowSettings] = useState(false)
   const [configFound, setConfigFound] = useState<boolean | null>(null)
@@ -386,11 +387,14 @@ useEffect(() => {
     })()
   }, [currentPdf])
 
-  // listen for fullscreen messages from the PDF viewer
+  // listen for messages from the PDF viewer
   useEffect(() => {
     const handler = (e: MessageEvent) => {
       if (e.data?.type === 'viewerFullscreen') {
         setPdfFullscreen(!!e.data.value)
+      } else if (e.data?.type === 'viewerTheme') {
+        setViewerLight(!!e.data.value)
+        setTheme(e.data.value ? 'light' : 'dark')
       }
     }
     window.addEventListener('message', handler)
@@ -791,6 +795,27 @@ useEffect(() => {
                   {currentPdf?.file.name}
                 </span>
                 <div className="flex flex-wrap items-center gap-2">
+                  <button
+                    onClick={() => {
+                      viewerRef.current?.contentWindow?.postMessage({
+                        type: 'toggleTheme'
+                      }, '*')
+                      const next = !viewerLight
+                      setViewerLight(next)
+                      setTheme(next ? 'light' : 'dark')
+                    }}
+                  >
+                    {viewerLight ? '🌞' : '🌙'}
+                  </button>
+                  <button
+                    onClick={() =>
+                      viewerRef.current?.contentWindow?.postMessage({
+                        type: 'toggleFullscreen'
+                      }, '*')
+                    }
+                  >
+                    ⛶
+                  </button>
                   <span>
                     Días restantes: {currentPdf ? daysUntil(currentPdf) : ''}
                   </span>
@@ -859,11 +884,6 @@ useEffect(() => {
               </div>
             )}
           </div>
-          {!viewerOpen && (
-            <div className="p-2 text-sm text-gray-500">
-              {currentPdf ? `Semana ${currentPdf.week} - ${currentPdf.subject}` : ''}
-            </div>
-          )}
         </section>
       </main>
     {/* Toast banner */}

--- a/public/visor/index.html
+++ b/public/visor/index.html
@@ -39,7 +39,7 @@
     #app-header {
       padding: 8px 16px;
       background: #323639;
-      display: flex;
+      display: none;
       align-items: center;
       justify-content: space-between;
       border-bottom: 1px solid #5f6368;
@@ -69,7 +69,7 @@
 
 
     #drop-zone {
-      position: absolute; top: 56px; left: 0; right: 0; bottom: 0;
+      position: absolute; top: 0; left: 0; right: 0; bottom: 0;
       display: flex; flex-direction: column; align-items: center; justify-content: center;
       background: #525659; z-index: 100;
     }
@@ -88,7 +88,7 @@
     #file-input { display: none; }
 
     #pdf-container {
-      position: absolute; top: 56px; left: 0; right: 0; bottom: 0;
+      position: absolute; top: 0; left: 0; right: 0; bottom: 0;
       overflow-y: auto; overflow-x: auto; padding: 16px 0; background: #525659;
     }
     body.light-mode #pdf-container { background: #fff; }
@@ -528,6 +528,8 @@
       // ========================================
       const container = document.getElementById('pdf-container');
       let zoomLevel = 1;
+      let redrawDelay = 200;
+      let redrawTimeout = null;
 
       function applyZoom() {
         const scale = BASE_SCALE * zoomLevel;
@@ -554,12 +556,19 @@
           }
         }
         currentPage = cur;
+        if (redrawTimeout) clearTimeout(redrawTimeout);
+        redrawTimeout = setTimeout(loadDrawingsFromStorage, redrawDelay);
       }
 
       window.addEventListener('message', (e) => {
-        if (e.data && e.data.type === 'resetZoom') {
+        if (!e.data) return;
+        if (e.data.type === 'resetZoom') {
           zoomLevel = 1;
           applyZoom();
+        } else if (e.data.type === 'toggleFullscreen') {
+          toggleFullscreen();
+        } else if (e.data.type === 'toggleTheme') {
+          toggleTheme();
         }
       });
 
@@ -643,10 +652,15 @@
       let creatingNote = false;
       const MQ = MathQuill.getInterface(2);
 
-      themeToggleBtn.addEventListener('click', () => {
+      function toggleTheme() {
         document.body.classList.toggle('light-mode');
-        themeToggleBtn.textContent = document.body.classList.contains('light-mode') ? '🌞' : '🌙';
-      });
+        if (themeToggleBtn) {
+          themeToggleBtn.textContent = document.body.classList.contains('light-mode') ? '🌞' : '🌙';
+        }
+        window.parent.postMessage({ type: 'viewerTheme', value: document.body.classList.contains('light-mode') }, '*');
+      }
+      if (themeToggleBtn) themeToggleBtn.addEventListener('click', toggleTheme);
+      window.parent.postMessage({ type: 'viewerTheme', value: document.body.classList.contains('light-mode') }, '*');
 
       // Persistencia de notas
       let directoryHandle = null;
@@ -725,6 +739,7 @@
       let shadowWidth = 0;
       let shadowOffset = 0;
       let brushOpacity = 1;
+      let redrawDelayInput;
       let eraseMode = false;
 
       const BRUSH_SETTINGS_KEY = 'draw-settings';
@@ -737,7 +752,8 @@
             shadowColor,
             shadowWidth,
             shadowOffset,
-            brushOpacity
+            brushOpacity,
+            redrawDelay
           }));
         } catch {}
       }
@@ -751,6 +767,7 @@
           if (data.shadowWidth) shadowWidth = data.shadowWidth;
           if (data.shadowOffset) shadowOffset = data.shadowOffset;
           if (typeof data.brushOpacity === 'number') brushOpacity = data.brushOpacity;
+          if (typeof data.redrawDelay === 'number') redrawDelay = data.redrawDelay;
         } catch {}
       }
 
@@ -770,6 +787,7 @@
         <label>Desplazamiento de <input type="range" id="tool-shadow-offset" min="0" max="50" value="0"></label>
         <label>Opacidad del <input type="range" id="tool-opacity-line" min="0" max="1" step="0.01" value="1"></label>
         <label>Opacidad de forma <input type="range" id="tool-opacity-shape" min="0" max="1" step="0.01" value="1"></label>
+        <label>Retraso redibujar <input type="range" id="tool-redraw-delay" min="0" max="2000" step="100" value="200"></label>
         <button id="tool-erase-btn">Borrar</button>
         <button id="tool-clear-all">Borrar todo</button>
       `;
@@ -781,6 +799,7 @@
       const shadowWidthInput = drawToolbar.querySelector('#tool-shadow-width');
       const shadowOffsetInput = drawToolbar.querySelector('#tool-shadow-offset');
       const opacityInput = drawToolbar.querySelector('#tool-opacity-line');
+      redrawDelayInput = drawToolbar.querySelector('#tool-redraw-delay');
       const eraseBtn = drawToolbar.querySelector('#tool-erase-btn');
       const clearAllBtn = drawToolbar.querySelector('#tool-clear-all');
 
@@ -790,6 +809,7 @@
       shadowWidthInput.addEventListener('input', e => { shadowWidth = parseInt(e.target.value, 10); saveBrushSettings(); });
       shadowOffsetInput.addEventListener('input', e => { shadowOffset = parseInt(e.target.value, 10); saveBrushSettings(); });
       opacityInput.addEventListener('input', e => { brushOpacity = parseFloat(e.target.value); saveBrushSettings(); });
+      redrawDelayInput.addEventListener('input', e => { redrawDelay = parseInt(e.target.value, 10); saveBrushSettings(); });
       eraseBtn.addEventListener('click', () => {
         eraseMode = !eraseMode;
         eraseBtn.textContent = eraseMode ? 'Dibujar' : 'Borrar';
@@ -803,6 +823,7 @@
         shadowWidthInput.value = shadowWidth;
         shadowOffsetInput.value = shadowOffset;
         opacityInput.value = brushOpacity;
+        redrawDelayInput.value = redrawDelay;
       }
 
       loadBrushSettings();
@@ -1171,7 +1192,7 @@
               document.removeEventListener('mousemove', updateFocusPreview);
               focusArea(pageNum, focusStart.xp, focusStart.yp, xp, yp);
               focusStart = null;
-              focusMode = false;
+              showNavIndicator('Haz dos clics para enfocar');
               return;
             }
 
@@ -1278,15 +1299,15 @@
         });
       }
 
-      fullscreenBtn.addEventListener('click', toggleFullscreen);
+      if (fullscreenBtn) fullscreenBtn.addEventListener('click', toggleFullscreen);
       function toggleFullscreen() {
         isFullscreen = !isFullscreen;
         if (isFullscreen) {
           document.body.classList.add('fullscreen');
-          fullscreenBtn.textContent = '⛷';
+          if (fullscreenBtn) fullscreenBtn.textContent = '⛷';
         } else {
           document.body.classList.remove('fullscreen');
-          fullscreenBtn.textContent = '⛶';
+          if (fullscreenBtn) fullscreenBtn.textContent = '⛶';
         }
         window.parent.postMessage({ type: 'viewerFullscreen', value: isFullscreen }, '*');
       }


### PR DESCRIPTION
## Summary
- add configurable redraw delay for annotations and restore drawings after zoom
- keep focus mode active across selections
- move fullscreen and theme toggles to main header and hide internal viewer bar
- remove week/subject footer for cleaner layout

## Testing
- `npm run lint` *(fails: requires interactive ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68b5adef6c4483309737b0ae87a5ed20