### PR TITLE
Hide viewer toolbar in PDF fullscreen and fix drawing offset

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -785,7 +785,8 @@ useEffect(() => {
           className={`flex flex-col flex-1 md:h-screen ${viewerOpen ? 'fixed inset-0 z-50 bg-white dark:bg-gray-900' : ''}`}
         >
           {viewerOpen ? (
-            <div className="flex flex-wrap items-center justify-between p-2 border-b gap-2">
+            !pdfFullscreen && (
+              <div className="flex flex-wrap items-center justify-between p-2 border-b gap-2">
               <span className="truncate" title={currentPdf?.file.name}>
                 {currentPdf?.file.name}
               </span>
@@ -827,7 +828,7 @@ useEffect(() => {
                   ✕
                 </button>
               </div>
-            </div>
+            )
           ) : (
             <div className="flex flex-wrap items-center justify-between p-2 border-b gap-2">
               <div className="flex items-center gap-2">

--- a/public/visor/index.html
+++ b/public/visor/index.html
@@ -2186,18 +2186,20 @@
         document.body.appendChild(overlay);
 
         const octx = drawOverlay.getContext('2d');
+        const scaleX = drawOverlay.width / drawOverlay.clientWidth;
+        const scaleY = drawOverlay.height / drawOverlay.clientHeight;
         let drawing = false;
         function start(e) {
           drawing = true;
           octx.strokeStyle = brushColor;
-          octx.lineWidth = brushWidth;
+          octx.lineWidth = brushWidth * scaleX;
           octx.lineCap = 'round';
           octx.beginPath();
-          octx.moveTo(e.offsetX, e.offsetY);
+          octx.moveTo(e.offsetX * scaleX, e.offsetY * scaleY);
         }
         function move(e) {
           if (!drawing) return;
-          octx.lineTo(e.offsetX, e.offsetY);
+          octx.lineTo(e.offsetX * scaleX, e.offsetY * scaleY);
           octx.stroke();
         }
         function end() { drawing = false; }


### PR DESCRIPTION
## Summary
- Hide the in-app toolbar when the embedded PDF viewer enters fullscreen mode.
- Correct focus mode drawing by scaling pointer coordinates to the high-DPI canvas.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68b711c0b1308330b6b53409a498e1e8