### PR TITLE
Hide header in viewer fullscreen and fix focus drawing offset

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -785,49 +785,51 @@ useEffect(() => {
           className={`flex flex-col flex-1 md:h-screen ${viewerOpen ? 'fixed inset-0 z-50 bg-white dark:bg-gray-900' : ''}`}
         >
           {viewerOpen ? (
-            <div className="flex flex-wrap items-center justify-between p-2 border-b gap-2">
-              <span className="truncate" title={currentPdf?.file.name}>
-                {currentPdf?.file.name}
-              </span>
-              <div className="flex flex-wrap items-center gap-2">
-                <span>
-                  Días restantes: {currentPdf ? daysUntil(currentPdf) : ''}
+            !pdfFullscreen && (
+              <div className="flex flex-wrap items-center justify-between p-2 border-b gap-2">
+                <span className="truncate" title={currentPdf?.file.name}>
+                  {currentPdf?.file.name}
                 </span>
-                <button
-                  onClick={() =>
-                    viewerRef.current?.contentWindow?.postMessage(
-                      { type: 'toggleFullscreen' },
-                      '*'
-                    )
-                  }
-                >
-                  {pdfFullscreen ? '🗗' : '⛶'}
-                </button>
-                <button
-                  onClick={() => {
-                    setTheme(theme === 'light' ? 'dark' : 'light')
-                    viewerRef.current?.contentWindow?.postMessage(
-                      { type: 'toggleTheme' },
-                      '*'
-                    )
-                  }}
-                >
-                  {theme === 'light' ? '🌞' : '🌙'}
-                </button>
-                <button
-                  onClick={() => {
-                    setViewerOpen(false)
-                    setPdfFullscreen(false)
-                    viewerRef.current?.contentWindow?.postMessage(
-                      { type: 'resetZoom' },
-                      '*'
-                    )
-                  }}
-                >
-                  ✕
-                </button>
+                <div className="flex flex-wrap items-center gap-2">
+                  <span>
+                    Días restantes: {currentPdf ? daysUntil(currentPdf) : ''}
+                  </span>
+                  <button
+                    onClick={() =>
+                      viewerRef.current?.contentWindow?.postMessage(
+                        { type: 'toggleFullscreen' },
+                        '*'
+                      )
+                    }
+                  >
+                    {pdfFullscreen ? '🗗' : '⛶'}
+                  </button>
+                  <button
+                    onClick={() => {
+                      setTheme(theme === 'light' ? 'dark' : 'light')
+                      viewerRef.current?.contentWindow?.postMessage(
+                        { type: 'toggleTheme' },
+                        '*'
+                      )
+                    }}
+                  >
+                    {theme === 'light' ? '🌞' : '🌙'}
+                  </button>
+                  <button
+                    onClick={() => {
+                      setViewerOpen(false)
+                      setPdfFullscreen(false)
+                      viewerRef.current?.contentWindow?.postMessage(
+                        { type: 'resetZoom' },
+                        '*'
+                      )
+                    }}
+                  >
+                    ✕
+                  </button>
+                </div>
               </div>
-            </div>
+            )
           ) : (
             <div className="flex flex-wrap items-center justify-between p-2 border-b gap-2">
               <div className="flex items-center gap-2">

--- a/public/visor/index.html
+++ b/public/visor/index.html
@@ -2186,18 +2186,20 @@
         document.body.appendChild(overlay);
 
         const octx = drawOverlay.getContext('2d');
+        const scaleX = drawOverlay.width / drawOverlay.offsetWidth;
+        const scaleY = drawOverlay.height / drawOverlay.offsetHeight;
         let drawing = false;
         function start(e) {
           drawing = true;
           octx.strokeStyle = brushColor;
-          octx.lineWidth = brushWidth;
+          octx.lineWidth = brushWidth * scaleX;
           octx.lineCap = 'round';
           octx.beginPath();
-          octx.moveTo(e.offsetX, e.offsetY);
+          octx.moveTo(e.offsetX * scaleX, e.offsetY * scaleY);
         }
         function move(e) {
           if (!drawing) return;
-          octx.lineTo(e.offsetX, e.offsetY);
+          octx.lineTo(e.offsetX * scaleX, e.offsetY * scaleY);
           octx.stroke();
         }
         function end() { drawing = false; }


### PR DESCRIPTION
## Summary
- Hide viewer header when PDF viewer enters fullscreen
- Correct focus mode drawing offset by scaling pointer coordinates

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68b711c0b1308330b6b53409a498e1e8