### PR TITLE
Simplify initial setup flow

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -16,9 +16,7 @@ type PdfFile = {
 
 export default function Home() {
   const { setTheme, theme } = useTheme()
-  const [started, setStarted] = useState(false)
   const [setupComplete, setSetupComplete] = useState(true)
-  const [step, setStep] = useState(0)
   const [names, setNames] = useState<string[]>([])
   const [theory, setTheory] = useState<Record<string, string>>({})
   const [practice, setPractice] = useState<Record<string, string>>({})
@@ -39,7 +37,6 @@ export default function Home() {
   const [pdfFullscreen, setPdfFullscreen] = useState(false)
   const [dragCategory, setDragCategory] = useState<'theory' | 'practice' | null>(null)
   const [showSettings, setShowSettings] = useState(false)
-  const [configFound, setConfigFound] = useState<boolean | null>(null)
   const [canonicalSubjects, setCanonicalSubjects] = useState<string[]>([])
   const folderInputRef = useRef<HTMLInputElement>(null)
   const viewerRef = useRef<HTMLIFrameElement>(null)
@@ -123,13 +120,17 @@ export default function Home() {
   }
 
   useEffect(() => {
-    if (step === 1) {
-      ;(async () => {
-        const ok = await loadConfig(dirFiles)
-        setConfigFound(ok)
-      })()
+    if (!setupComplete) {
+      const handleKey = (e: KeyboardEvent) => {
+        if (e.key === "Enter") {
+          e.preventDefault()
+          folderInputRef.current?.click()
+        }
+      }
+      window.addEventListener("keydown", handleKey)
+      return () => window.removeEventListener("keydown", handleKey)
     }
-  }, [step, dirFiles])
+  }, [setupComplete])
 
   // theme and setup flag
   useEffect(() => {
@@ -171,18 +172,6 @@ export default function Home() {
     })()
   }, [])
 
-  // greeting handler
-  useEffect(() => {
-    const handler = () => setStarted(true)
-    if (!started) {
-      window.addEventListener("keydown", handler)
-      window.addEventListener("pointerdown", handler)
-      return () => {
-        window.removeEventListener("keydown", handler)
-        window.removeEventListener("pointerdown", handler)
-      }
-    }
-  }, [started])
 
   // load completed from storage
   useEffect(() => {
@@ -397,78 +386,35 @@ useEffect(() => {
     return () => window.removeEventListener('message', handler)
   }, [])
 
-  // greeting screen
-  if (!mounted) return null
-  if (!started) {
-    const hour = new Date().getHours()
-    const greeting = hour >= 19 || hour < 6 ? "Buenas noches" : "Buenos días"
+    if (!mounted) return null
+  if (!setupComplete) {
     return (
-      <main className="min-h-screen flex items-center justify-center text-2xl">
-        <p>{greeting}. Toca la pantalla o presiona una tecla para continuar.</p>
+      <main className="min-h-screen flex flex-col items-center justify-center gap-4 p-4">
+        <h1 className="text-xl">Selecciona la carpeta "gestor"</h1>
+        <button
+          className="px-4 py-2 border rounded"
+          onClick={() => folderInputRef.current?.click()}
+        >
+          Cargar carpeta
+        </button>
+        <input
+          ref={folderInputRef}
+          type="file"
+          // @ts-expect-error webkitdirectory es no estándar
+          webkitdirectory=""
+          className="hidden"
+          onChange={async (e) => {
+            const rawFiles = Array.from(e.target.files || [])
+            const files = filterSystemFiles(rawFiles)
+            setDirFiles(files)
+            await loadConfig(files)
+            void restoreCheckHistory(rawFiles)
+            localStorage.setItem("setupComplete", "1")
+            setSetupComplete(true)
+          }}
+        />
       </main>
     )
-  }
-
-  // configuration wizard
-  if (!setupComplete) {
-    switch (step) {
-      case 0: {
-        return (
-          <main className="min-h-screen flex flex-col items-center justify-center gap-4 p-4">
-            <h1 className="text-xl">Comencemos a configurar el entorno</h1>
-            <p>Paso 1: Selecciona la carpeta "gestor"</p>
-            <input
-              type="file"
-              // @ts-expect-error webkitdirectory es no estándar
-              webkitdirectory=""
-              onChange={(e) => {
-                const rawFiles = Array.from(e.target.files || [])
-                const files = filterSystemFiles(rawFiles)
-                setDirFiles(files)
-                void restoreCheckHistory(rawFiles)
-                setStep(1)
-              }}
-            />
-          </main>
-        )
-      }
-      case 1: {
-        return (
-          <main className="min-h-screen flex flex-col items-center justify-center gap-4 p-4">
-            {configFound === null && <p>Buscando configuración previa...</p>}
-            {configFound === true && (
-              <>
-                <p>Configuración encontrada. Bienvenido.</p>
-                <button
-                  className="px-4 py-2 border rounded"
-                  onClick={() => {
-                    localStorage.setItem("setupComplete", "1")
-                    setSetupComplete(true)
-                    setStarted(false)
-                  }}
-                >
-                  Continuar
-                </button>
-              </>
-            )}
-            {configFound === false && (
-              <>
-                <p>No se encontró configuración previa.</p>
-                <button
-                  className="px-4 py-2 border rounded"
-                  onClick={() => {
-                    setSetupComplete(true)
-                    setStarted(false)
-                  }}
-                >
-                  Continuar
-                </button>
-              </>
-            )}
-          </main>
-        )
-      }
-    }
   }
 
   const daysUntil = (pdf: PdfFile) => {


### PR DESCRIPTION
## Summary
- Remove greeting/config wizard and load directly after selecting folder
- Allow pressing Enter to trigger folder selection

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68b7245824088330a10f9bb322c7ffeb