### PR TITLE
Use .url extension for dropped links

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -579,13 +579,13 @@ useEffect(() => {
       return
     }
     const category = dragCategory || 'theory'
-    const suggested = data.includes('youtube') ? 'video.lnk' : 'enlace.lnk'
+    const suggested = data.includes('youtube') ? 'video.url' : 'enlace.url'
     const name = prompt('Nombre del enlace:', suggested)
     if (!name) {
       setDragCategory(null)
       return
     }
-    const fileName = name.endsWith('.lnk') ? name : `${name}.lnk`
+    const fileName = name.endsWith('.url') ? name : `${name}.url`
     const content = `[InternetShortcut]\nURL=${data}\n`
     const file = new File([content], fileName, { type: 'text/plain' })
     Object.defineProperty(file, 'webkitRelativePath', {


### PR DESCRIPTION
## Summary
- save dropped links with `.url` extension so Windows and app treat them as text shortcuts

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: requires interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68ba13ac58948330a5b63e7ccfd5087b