### PR TITLE
Include link shortcut files in directory tree

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -327,6 +327,10 @@ useEffect(() => {
       if (rel.split("/").includes("system")) continue
       const parts = rel.split("/") || []
       if (parts.length >= 5) {
+        const ext = file.name.toLowerCase().split(".").pop() || ""
+        const isPdf = ext === "pdf"
+        const isLink = ext === "lnk" || ext === "url"
+        if (!isPdf && !isLink) continue
         const weekPart = parts[1]
         const subject = parts[2]
         const table = parts[3].toLowerCase().includes("pract")
@@ -341,7 +345,7 @@ useEffect(() => {
           week,
           subject,
           tableType: table,
-          isPdf: file.name.toLowerCase().endsWith(".pdf"),
+          isPdf,
         })
       }
     }


### PR DESCRIPTION
## Summary
- parse directory entries for `.lnk` and `.url` shortcuts so they appear alongside PDFs

## Testing
- `pnpm lint` *(fails: Command failed with exit code 1, ESLint configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68ba1532a6688330b71b89ce0650a690