### PR TITLE
chore: allow link files

### DIFF
--- a/public/visor/index.html
+++ b/public/visor/index.html
@@ -404,10 +404,10 @@
     <div class="header-center" id="file-info">Visor PDF</div>
     <div class="header-right">
        NUEVOS: carpeta de PDFs e iniciar 
-      <button class="control-btn" id="pdf-folder-btn" title="Seleccionar carpeta de PDFs">📂 PDFs</button>
-      <button class="control-btn" id="start-btn" title="Abrir primer PDF" disabled>▶ iniciar →</button>
+      <button class="control-btn" id="pdf-folder-btn" title="Seleccionar carpeta">📂 Carpeta</button>
+      <button class="control-btn" id="start-btn" title="Abrir primer archivo" disabled>▶ iniciar →</button>
       <input type="file" id="pdf-folder-input" class="hidden" style="display:none"
-        accept="application/pdf" multiple webkitdirectory directory />
+        multiple webkitdirectory directory />
 
       <button class="control-btn" id="fullscreen-btn">⛶</button>
 
@@ -427,10 +427,10 @@
   <div id="drop-zone">
     <div class="upload-area" id="upload-area">
       <div class="upload-icon">📄</div>
-      <div class="upload-text">Seleccionar PDF</div>
+      <div class="upload-text">Seleccionar archivo</div>
       <div class="upload-subtext">Arrastra un archivo aquí o haz clic para seleccionar</div>
     </div>
-    <input type="file" id="file-input" accept="application/pdf">
+    <input type="file" id="file-input">
   </div>
 
   <div id="pdf-container">
@@ -1364,34 +1364,51 @@
       uploadArea.addEventListener('click', () => fileInput.click());
       uploadArea.addEventListener('dragover', (e) => { e.preventDefault(); uploadArea.classList.add('dragover'); });
       uploadArea.addEventListener('dragleave', () => { uploadArea.classList.remove('dragover'); });
-      uploadArea.addEventListener('drop', (e) => {
+      uploadArea.addEventListener('drop', async (e) => {
         e.preventDefault(); uploadArea.classList.remove('dragover');
         const files = e.dataTransfer.files;
         if (files.length > 0) {
-          const file = files[0];
-          if (file.type === 'application/pdf') {
-            const url = URL.createObjectURL(file);
-            currentObjectUrl = url;
-            currentPdfIndex = -1;
-            loadPdf(url, file.name, file.lastModified);
-          } else {
-            showToast('Por favor selecciona un archivo PDF', 'error');
-          }
+          await openFile(files[0]);
         }
       });
-      fileInput.addEventListener('change', (e) => {
+      fileInput.addEventListener('change', async (e) => {
         const file = e.target.files[0];
         if (file) {
-          if (file.type === 'application/pdf') {
-            const url = URL.createObjectURL(file);
-            currentObjectUrl = url;
-            currentPdfIndex = -1;
-            loadPdf(url, file.name, file.lastModified);
-          } else {
-            showToast('Por favor selecciona un archivo PDF', 'error');
-          }
+          await openFile(file);
         }
       });
+
+      async function readLinkFile(file) {
+        const buf = await file.arrayBuffer();
+        const bytes = new Uint8Array(buf);
+        let ascii = '';
+        for (const b of bytes) {
+          ascii += b >= 32 && b <= 126 ? String.fromCharCode(b) : '\x00';
+        }
+        let utf16 = '';
+        for (let i = 0; i + 1 < bytes.length; i += 2) {
+          const code = bytes[i] | (bytes[i + 1] << 8);
+          utf16 += code >= 32 && code <= 126 ? String.fromCharCode(code) : '\x00';
+        }
+        const match = ascii.match(/https?:\/\/[^\s"']+/) || utf16.match(/https?:\/\/[^\s"']+/);
+        return match ? match[0] : null;
+      }
+
+      async function openFile(file) {
+        if (file.name.toLowerCase().endsWith('.pdf')) {
+          const url = URL.createObjectURL(file);
+          currentObjectUrl = url;
+          currentPdfIndex = -1;
+          loadPdf(url, file.name, file.lastModified);
+        } else {
+          const url = await readLinkFile(file);
+          if (url) {
+            window.open(url, '_blank');
+          } else {
+            showToast('Archivo no compatible', 'error');
+          }
+        }
+      }
 
       // ========================================
       // CARPETA DE PDFs + NAVEGACIÓN ENTRE PDFs
@@ -1409,12 +1426,12 @@
           const list = [];
           // @ts-ignore
           for await (const [name, handle] of dirHandle.entries()) {
-            if (handle.kind === 'file' && isPdf(name)) list.push({ name, handle });
+            if (handle.kind === 'file') list.push({ name, handle });
           }
-          if (!list.length) { showToast('La carpeta no contiene PDFs', 'error'); startBtn.disabled = true; pdfEntries = []; return; }
+          if (!list.length) { showToast('La carpeta no contiene archivos', 'error'); startBtn.disabled = true; pdfEntries = []; return; }
           list.sort((a,b) => naturalCompare(a.name,b.name));
           pdfEntries = list; startBtn.disabled = false;
-          showToast(`Listados ${pdfEntries.length} PDFs`, 'success');
+          showToast(`Listados ${pdfEntries.length} archivos`, 'success');
           const lastIdx = parseInt(localStorage.getItem('lastPdfIndex') || '0', 10);
           await loadPdfFromEntry(!isNaN(lastIdx) && lastIdx < pdfEntries.length ? lastIdx : 0, 'first');
         } catch (e) {
@@ -1424,22 +1441,22 @@
       });
 
       pdfFolderInput.addEventListener('change', (e) => {
-        const files = Array.from(e.target.files || []).filter(f => isPdf(f.name));
+        const files = Array.from(e.target.files || []);
         if (!files.length) {
-          showToast('La carpeta seleccionada no contiene PDFs', 'error');
+          showToast('La carpeta seleccionada no contiene archivos', 'error');
           startBtn.disabled = true; pdfEntries = []; return;
         }
         const list = files.map(f => ({ name: f.name, file: f }));
         list.sort((a,b) => naturalCompare(a.name,b.name));
         pdfEntries = list; pdfDirectoryHandle = null;
         startBtn.disabled = false;
-        showToast(`Listados ${pdfEntries.length} PDFs (fallback)`, 'success');
+        showToast(`Listados ${pdfEntries.length} archivos (fallback)`, 'success');
         const lastIdx = parseInt(localStorage.getItem('lastPdfIndex') || '0', 10);
         loadPdfFromEntry(!isNaN(lastIdx) && lastIdx < pdfEntries.length ? lastIdx : 0, 'first');
       });
 
       startBtn.addEventListener('click', async () => {
-        if (!pdfEntries.length) { showToast('Primero selecciona una carpeta de PDFs', 'info'); return; }
+        if (!pdfEntries.length) { showToast('Primero selecciona una carpeta', 'info'); return; }
         await loadPdfFromEntry(0, 'first');
       });
 
@@ -1449,16 +1466,18 @@
           let arrayBuffer;
           let uniqueKey;
           const entry = pdfEntries[index];
-          if (entry.handle) {
-            const file = await entry.handle.getFile();
-            arrayBuffer = await file.arrayBuffer();
-            uniqueKey = file.lastModified;
-          } else if (entry.file) {
-            arrayBuffer = await entry.file.arrayBuffer();
-            uniqueKey = entry.file.lastModified;
-          } else {
-            throw new Error('Entrada inválida');
+          const file = entry.handle ? await entry.handle.getFile() : entry.file;
+          if (!isPdf(file.name)) {
+            const url = await readLinkFile(file);
+            if (url) {
+              window.open(url, '_blank');
+            } else {
+              showToast('Archivo no compatible', 'error');
+            }
+            return;
           }
+          arrayBuffer = await file.arrayBuffer();
+          uniqueKey = file.lastModified;
           if (currentObjectUrl) { try { URL.revokeObjectURL(currentObjectUrl); } catch {} currentObjectUrl = null; }
           const blob = new Blob([arrayBuffer], { type: 'application/pdf' });
           const url = URL.createObjectURL(blob);
@@ -1468,7 +1487,7 @@
           currentPdfIndex = index;
           localStorage.setItem('lastPdfIndex', String(index));
           localStorage.setItem('lastPdfName', entry.name);
-          showNavIndicator(`PDF ${index + 1}/${pdfEntries.length}: ${entry.name}`);
+          showNavIndicator(`Archivo ${index + 1}/${pdfEntries.length}: ${entry.name}`);
         } catch (e) {
           console.error(e);
           showToast('No se pudo abrir el PDF.', 'error');


### PR DESCRIPTION
## Summary
- support URLs stored in shortcut files by decoding ASCII and UTF-16 strings
- remove PDF-only filters in viewer and handle .lnk/.url files
- include every file when listing directory contents

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ba1e6111448330b9ac9255cdbe3069