### PR TITLE
feat: allow link files

### DIFF
--- a/public/visor/index.html
+++ b/public/visor/index.html
@@ -96,7 +96,16 @@
       position: absolute; top: 56px; left: 0; right: 0; bottom: 0;
       overflow-y: auto; overflow-x: auto; padding: 16px 0; background: #525659;
     }
+    #pdf-container.hidden { display: none; }
     body.light-mode #pdf-container { background: #fff; }
+
+    #generic-viewer {
+      position: absolute; top: 56px; left: 0; right: 0; bottom: 0;
+      width: 100%; height: calc(100vh - 56px);
+      border: none; background: #525659;
+    }
+    #generic-viewer.hidden { display: none; }
+    body.light-mode #generic-viewer { background: #fff; }
 
     /* Desactivar scroll mientras carga o se guarda */
     #pdf-container.no-scroll {
@@ -404,10 +413,10 @@
     <div class="header-center" id="file-info">Visor PDF</div>
     <div class="header-right">
        NUEVOS: carpeta de PDFs e iniciar 
-      <button class="control-btn" id="pdf-folder-btn" title="Seleccionar carpeta de PDFs">📂 PDFs</button>
-      <button class="control-btn" id="start-btn" title="Abrir primer PDF" disabled>▶ iniciar →</button>
+      <button class="control-btn" id="pdf-folder-btn" title="Seleccionar carpeta">📂 Carpeta</button>
+      <button class="control-btn" id="start-btn" title="Abrir primer archivo" disabled>▶ iniciar →</button>
       <input type="file" id="pdf-folder-input" class="hidden" style="display:none"
-        accept="application/pdf" multiple webkitdirectory directory />
+        multiple webkitdirectory directory />
 
       <button class="control-btn" id="fullscreen-btn">⛶</button>
 
@@ -427,10 +436,10 @@
   <div id="drop-zone">
     <div class="upload-area" id="upload-area">
       <div class="upload-icon">📄</div>
-      <div class="upload-text">Seleccionar PDF</div>
+      <div class="upload-text">Seleccionar archivo</div>
       <div class="upload-subtext">Arrastra un archivo aquí o haz clic para seleccionar</div>
     </div>
-    <input type="file" id="file-input" accept="application/pdf">
+    <input type="file" id="file-input">
   </div>
 
   <div id="pdf-container">
@@ -442,6 +451,8 @@
       </div>
     </div>
   </div>
+
+  <iframe id="generic-viewer" class="hidden"></iframe>
 
   <div id="permission-modal" class="permission-modal hidden">
     <div class="permission-content">
@@ -543,6 +554,7 @@
       // VARIABLES GLOBALES
       // ========================================
       const container = document.getElementById('pdf-container');
+      const genericViewer = document.getElementById('generic-viewer');
       let zoomLevel = 1;
 
       function applyZoom() {
@@ -1364,40 +1376,96 @@
       uploadArea.addEventListener('click', () => fileInput.click());
       uploadArea.addEventListener('dragover', (e) => { e.preventDefault(); uploadArea.classList.add('dragover'); });
       uploadArea.addEventListener('dragleave', () => { uploadArea.classList.remove('dragover'); });
-      uploadArea.addEventListener('drop', (e) => {
+      uploadArea.addEventListener('drop', async (e) => {
         e.preventDefault(); uploadArea.classList.remove('dragover');
         const files = e.dataTransfer.files;
         if (files.length > 0) {
-          const file = files[0];
-          if (file.type === 'application/pdf') {
-            const url = URL.createObjectURL(file);
-            currentObjectUrl = url;
-            currentPdfIndex = -1;
-            loadPdf(url, file.name, file.lastModified);
-          } else {
-            showToast('Por favor selecciona un archivo PDF', 'error');
-          }
+          await openFile(files[0]);
         }
       });
-      fileInput.addEventListener('change', (e) => {
+      fileInput.addEventListener('change', async (e) => {
         const file = e.target.files[0];
         if (file) {
-          if (file.type === 'application/pdf') {
-            const url = URL.createObjectURL(file);
-            currentObjectUrl = url;
-            currentPdfIndex = -1;
-            loadPdf(url, file.name, file.lastModified);
-          } else {
-            showToast('Por favor selecciona un archivo PDF', 'error');
-          }
+          await openFile(file);
         }
       });
+
+      async function readLinkFile(file) {
+        const buf = await file.arrayBuffer();
+        const bytes = new Uint8Array(buf);
+        let ascii = '';
+        for (const b of bytes) {
+          ascii += b >= 32 && b <= 126 ? String.fromCharCode(b) : '\x00';
+        }
+        let utf16 = '';
+        for (let i = 0; i + 1 < bytes.length; i += 2) {
+          const code = bytes[i] | (bytes[i + 1] << 8);
+          utf16 += code >= 32 && code <= 126 ? String.fromCharCode(code) : '\x00';
+        }
+        const match = ascii.match(/https?:\/\/[^\s"']+/) || utf16.match(/https?:\/\/[^\s"']+/);
+        return match ? match[0] : null;
+      }
+
+      function toEmbedUrl(url) {
+        try {
+          const u = new URL(url);
+          if (u.hostname.includes('youtube.com')) {
+            const v = u.searchParams.get('v');
+            if (v) return `https://www.youtube.com/embed/${v}`;
+            const parts = u.pathname.split('/');
+            const i = parts.indexOf('embed');
+            if (i >= 0 && parts[i + 1]) return `https://www.youtube.com/embed/${parts[i + 1]}`;
+          }
+          if (u.hostname === 'youtu.be') {
+            const id = u.pathname.slice(1);
+            if (id) return `https://www.youtube.com/embed/${id}`;
+          }
+          return url;
+        } catch {
+          return url;
+        }
+      }
+
+      async function openFile(file) {
+        const name = file.name.toLowerCase();
+        if (isPdf(name)) {
+          if (currentObjectUrl) { try { URL.revokeObjectURL(currentObjectUrl); } catch {} }
+          const url = URL.createObjectURL(file);
+          currentObjectUrl = url;
+          currentPdfIndex = -1;
+          container.classList.remove('hidden');
+          genericViewer.classList.add('hidden');
+          loadPdf(url, file.name, file.lastModified);
+        } else {
+          let url = null;
+          if (isLink(name)) {
+            const raw = await readLinkFile(file);
+            if (raw) url = toEmbedUrl(raw);
+          }
+          if (!url) {
+            if (currentObjectUrl) { try { URL.revokeObjectURL(currentObjectUrl); } catch {} }
+            url = URL.createObjectURL(file);
+            currentObjectUrl = url;
+          } else {
+            if (currentObjectUrl) { try { URL.revokeObjectURL(currentObjectUrl); } catch {} }
+            currentObjectUrl = null;
+          }
+          container.classList.add('hidden');
+          genericViewer.classList.remove('hidden');
+          genericViewer.src = url;
+          currentPdfIndex = -1;
+        }
+      }
 
       // ========================================
       // CARPETA DE PDFs + NAVEGACIÓN ENTRE PDFs
       // ========================================
       function naturalCompare(a, b) { return a.localeCompare(b, undefined, { numeric: true, sensitivity: 'base' }); }
       function isPdf(name) { return name.toLowerCase().endsWith('.pdf'); }
+      function isLink(name) {
+        const n = name.toLowerCase();
+        return n.endsWith('.lnk') || n.endsWith('.url');
+      }
       function supportsDirPicker() { return 'showDirectoryPicker' in window; }
       function supportsFileSystemAccess() { return 'showDirectoryPicker' in window; }
 
@@ -1409,80 +1477,93 @@
           const list = [];
           // @ts-ignore
           for await (const [name, handle] of dirHandle.entries()) {
-            if (handle.kind === 'file' && isPdf(name)) list.push({ name, handle });
+            if (handle.kind === 'file') list.push({ name, handle });
           }
-          if (!list.length) { showToast('La carpeta no contiene PDFs', 'error'); startBtn.disabled = true; pdfEntries = []; return; }
+          if (!list.length) { showToast('La carpeta está vacía', 'error'); startBtn.disabled = true; pdfEntries = []; return; }
           list.sort((a,b) => naturalCompare(a.name,b.name));
           pdfEntries = list; startBtn.disabled = false;
-          showToast(`Listados ${pdfEntries.length} PDFs`, 'success');
+          showToast(`Listados ${pdfEntries.length} archivos`, 'success');
           const lastIdx = parseInt(localStorage.getItem('lastPdfIndex') || '0', 10);
           await loadPdfFromEntry(!isNaN(lastIdx) && lastIdx < pdfEntries.length ? lastIdx : 0, 'first');
         } catch (e) {
           if (e && e.name === 'AbortError') return;
-          showToast('No se pudo acceder a la carpeta de PDFs', 'error');
+          showToast('No se pudo acceder a la carpeta', 'error');
         }
       });
 
       pdfFolderInput.addEventListener('change', (e) => {
-        const files = Array.from(e.target.files || []).filter(f => isPdf(f.name));
+        const files = Array.from(e.target.files || []);
         if (!files.length) {
-          showToast('La carpeta seleccionada no contiene PDFs', 'error');
+          showToast('La carpeta seleccionada está vacía', 'error');
           startBtn.disabled = true; pdfEntries = []; return;
         }
         const list = files.map(f => ({ name: f.name, file: f }));
         list.sort((a,b) => naturalCompare(a.name,b.name));
         pdfEntries = list; pdfDirectoryHandle = null;
         startBtn.disabled = false;
-        showToast(`Listados ${pdfEntries.length} PDFs (fallback)`, 'success');
+        showToast(`Listados ${pdfEntries.length} archivos (fallback)`, 'success');
         const lastIdx = parseInt(localStorage.getItem('lastPdfIndex') || '0', 10);
         loadPdfFromEntry(!isNaN(lastIdx) && lastIdx < pdfEntries.length ? lastIdx : 0, 'first');
       });
 
       startBtn.addEventListener('click', async () => {
-        if (!pdfEntries.length) { showToast('Primero selecciona una carpeta de PDFs', 'info'); return; }
+        if (!pdfEntries.length) { showToast('Primero selecciona una carpeta', 'info'); return; }
         await loadPdfFromEntry(0, 'first');
       });
 
       async function loadPdfFromEntry(index, after='first') {
         if (index < 0 || index >= pdfEntries.length) return;
         try {
-          let arrayBuffer;
-          let uniqueKey;
           const entry = pdfEntries[index];
-          if (entry.handle) {
-            const file = await entry.handle.getFile();
-            arrayBuffer = await file.arrayBuffer();
-            uniqueKey = file.lastModified;
-          } else if (entry.file) {
-            arrayBuffer = await entry.file.arrayBuffer();
-            uniqueKey = entry.file.lastModified;
+          const file = entry.handle ? await entry.handle.getFile() : entry.file;
+          const name = file.name.toLowerCase();
+          if (isPdf(name)) {
+            const arrayBuffer = await file.arrayBuffer();
+            const uniqueKey = file.lastModified;
+            if (currentObjectUrl) { try { URL.revokeObjectURL(currentObjectUrl); } catch {} currentObjectUrl = null; }
+            const blob = new Blob([arrayBuffer], { type: 'application/pdf' });
+            const url = URL.createObjectURL(blob);
+            currentObjectUrl = url;
+            container.classList.remove('hidden');
+            genericViewer.classList.add('hidden');
+            pendingAfterLoadGoTo = after;
+            await loadPdf(url, entry.name, uniqueKey);
           } else {
-            throw new Error('Entrada inválida');
+            let url = null;
+            if (isLink(name)) {
+              const raw = await readLinkFile(file);
+              if (raw) url = toEmbedUrl(raw);
+            }
+            if (!url) {
+              if (currentObjectUrl) { try { URL.revokeObjectURL(currentObjectUrl); } catch {} }
+              url = URL.createObjectURL(file);
+              currentObjectUrl = url;
+            } else {
+              if (currentObjectUrl) { try { URL.revokeObjectURL(currentObjectUrl); } catch {} }
+              currentObjectUrl = null;
+            }
+            container.classList.add('hidden');
+            genericViewer.classList.remove('hidden');
+            genericViewer.src = url;
           }
-          if (currentObjectUrl) { try { URL.revokeObjectURL(currentObjectUrl); } catch {} currentObjectUrl = null; }
-          const blob = new Blob([arrayBuffer], { type: 'application/pdf' });
-          const url = URL.createObjectURL(blob);
-          currentObjectUrl = url;
-          pendingAfterLoadGoTo = after;
-          await loadPdf(url, entry.name, uniqueKey);
           currentPdfIndex = index;
           localStorage.setItem('lastPdfIndex', String(index));
           localStorage.setItem('lastPdfName', entry.name);
-          showNavIndicator(`PDF ${index + 1}/${pdfEntries.length}: ${entry.name}`);
+          showNavIndicator(`Archivo ${index + 1}/${pdfEntries.length}: ${entry.name}`);
         } catch (e) {
           console.error(e);
-          showToast('No se pudo abrir el PDF.', 'error');
+          showToast('No se pudo abrir el archivo.', 'error');
         }
       }
       async function goToNextPdf() {
         const idx = currentPdfIndex + 1;
         if (idx < pdfEntries.length) await loadPdfFromEntry(idx, 'first');
-        else showToast('No hay siguiente PDF', 'info');
+        else showToast('No hay siguiente archivo', 'info');
       }
       async function goToPrevPdf() {
         const idx = currentPdfIndex - 1;
         if (idx >= 0) await loadPdfFromEntry(idx, 'last');
-        else showToast('No hay PDF anterior', 'info');
+        else showToast('No hay archivo anterior', 'info');
       }
 
       // ========================================
@@ -1597,14 +1678,14 @@
               if (targetPage > 1) {
                 scrollToPage(targetPage - 1);
               } else if (currentPdfIndex > 0) {
-                showNavIndicator('Cargando PDF anterior…');
+                showNavIndicator('Cargando archivo anterior…');
                 await goToPrevPdf();
               }
             } else if (e.key === 'ArrowRight') {
               if (targetPage < totalPages) {
                 scrollToPage(targetPage + 1);
               } else if (currentPdfIndex >= 0 && currentPdfIndex < pdfEntries.length - 1) {
-                showNavIndicator('Cargando siguiente PDF…');
+                showNavIndicator('Cargando siguiente archivo…');
                 await goToNextPdf();
               }
             }


### PR DESCRIPTION
## Summary
- support URLs stored in shortcut files by decoding ASCII and UTF-16 strings
- remove file type filtering and render non-PDF content inside the viewer

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: interactive ESLint prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68ba1e6111448330b9ac9255cdbe3069