### PR TITLE
Allow viewer for non-PDF files

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -539,7 +539,6 @@ useEffect(() => {
     } else {
       setCurrentPdf(pdf)
     }
-    if (!pdf.isPdf) setViewerOpen(false)
   }
 
   const prevPdf = () => {
@@ -547,7 +546,6 @@ useEffect(() => {
       const i = queueIndex - 1
       setQueueIndex(i)
       setCurrentPdf(queue[i])
-      if (!queue[i].isPdf) setViewerOpen(false)
     }
   }
 
@@ -556,7 +554,6 @@ useEffect(() => {
       const i = queueIndex + 1
       setQueueIndex(i)
       setCurrentPdf(queue[i])
-      if (!queue[i].isPdf) setViewerOpen(false)
     }
   }
 


### PR DESCRIPTION
## Summary
- Keep resource viewer open when navigating to non-PDF files

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68bb406900b48330be067c4ed01f2be6