### PR TITLE
feat: preview youtube links from lnk files

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -327,6 +327,8 @@ useEffect(() => {
       if (rel.split("/").includes("system")) continue
       const parts = rel.split("/") || []
       if (parts.length >= 5) {
+        const name = file.name.toLowerCase()
+        if (!name.endsWith('.pdf') && !name.endsWith('.lnk')) continue
         const weekPart = parts[1]
         const subject = parts[2]
         const table = parts[3].toLowerCase().includes("pract")
@@ -429,7 +431,8 @@ useEffect(() => {
 
   const toEmbedUrl = (url: string) => {
     try {
-      const u = new URL(url)
+      const clean = url.replace(/["']+$/g, "")
+      const u = new URL(clean)
       if (u.hostname.includes("youtube.com")) {
         const v = u.searchParams.get("v")
         if (v) return `https://www.youtube.com/embed/${v}`
@@ -443,9 +446,9 @@ useEffect(() => {
         const id = u.pathname.slice(1)
         if (id) return `https://www.youtube.com/embed/${id}`
       }
-      return url
+      return clean
     } catch {
-      return url
+      return url.replace(/["']+$/g, "")
     }
   }
 
@@ -467,8 +470,9 @@ useEffect(() => {
       try {
         const buf = await currentPdf.file.arrayBuffer()
         const text = new TextDecoder().decode(buf).replace(/\u0000/g, "")
-        const match = text.match(/https?:\/\/[^\s]+/)
-        const raw = match ? match[0] : null
+        const matches = text.match(/https?:\/\/[^\s"']+/g) || []
+        const raw =
+          matches.find((m) => m.includes("youtube")) || matches[0] || null
         const url = raw ? toEmbedUrl(raw) : null
         setEmbedUrl(url)
       } catch {


### PR DESCRIPTION
## Summary
- sanitize extracted URLs and translate YouTube links to embeddable form
- scan .lnk contents for YouTube URLs and display them in the preview iframe
- include `.lnk` files when building the file tree so shortcuts appear alongside PDFs

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68bb42fe579c83308cb541e06e9ee503