### PR TITLE
feat: preview youtube links from lnk files

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -50,9 +50,12 @@ const loadHandle = async (): Promise<FileSystemDirectoryHandle | null> => {
   return handle
 }
 
-const verifyPermission = async (handle: FileSystemDirectoryHandle) => {
-  if ((await handle.queryPermission({ mode: "read" })) === "granted") return true
-  if ((await handle.requestPermission({ mode: "read" })) === "granted") return true
+const verifyPermission = async (
+  handle: any,
+  mode: "read" | "readwrite" = "read",
+) => {
+  if ((await handle.queryPermission({ mode })) === "granted") return true
+  if ((await handle.requestPermission({ mode })) === "granted") return true
   return false
 }
 
@@ -64,11 +67,16 @@ const readAllFiles = async (dir: FileSystemDirectoryHandle) => {
   ): Promise<void> => {
     for await (const [name, handle] of (directory as any).entries()) {
       if (handle.kind === "file") {
-        const file = await handle.getFile()
-        Object.defineProperty(file, "webkitRelativePath", {
-          value: `${path}${name}`,
-        })
-        files.push(file)
+        try {
+          if (!(await verifyPermission(handle))) continue
+          const file = await handle.getFile()
+          Object.defineProperty(file, "webkitRelativePath", {
+            value: `${path}${name}`,
+          })
+          files.push(file)
+        } catch (err) {
+          console.warn("Skipping file", name, err)
+        }
       } else if (handle.kind === "directory") {
         await traverse(handle, `${path}${name}/`)
       }
@@ -88,6 +96,7 @@ export default function Home() {
   const [weeks, setWeeks] = useState(1)
   const [unlockedWeeks, setUnlockedWeeks] = useState(1)
   const [dirFiles, setDirFiles] = useState<File[]>([])
+  const [dirHandle, setDirHandle] = useState<FileSystemDirectoryHandle | null>(null)
   const [fileTree, setFileTree] = useState<Record<number, Record<string, PdfFile[]>>>({})
   const [completed, setCompleted] = useState<Record<string, boolean>>({})
   const [currentPdf, setCurrentPdf] = useState<PdfFile | null>(null)
@@ -114,6 +123,25 @@ export default function Home() {
     files.filter(
       (f) => !((f as any).webkitRelativePath || "").split("/").includes("system"),
     )
+
+  const sanitize = (name: string) => name.replace(/[<>:"/\\|?*]/g, "_")
+
+  const writeFile = async (path: string, file: File): Promise<string> => {
+    if (!dirHandle) throw new Error("no directory handle")
+    if (!(await verifyPermission(dirHandle, "readwrite")))
+      throw new Error("permission denied")
+    const parts = path.split("/").filter(Boolean).map(sanitize)
+    let dir = dirHandle
+    for (let i = 0; i < parts.length - 1; i++) {
+      dir = await dir.getDirectoryHandle(parts[i], { create: true })
+    }
+    const fname = parts[parts.length - 1]
+    const fh = await dir.getFileHandle(fname, { create: true })
+    const writable = await fh.createWritable()
+    await writable.write(file)
+    await writable.close()
+    return parts.join("/")
+  }
 
   const loadConfig = async (files: File[]) => {
     const cfg = files.find((f) => f.name === "config.json")
@@ -165,6 +193,7 @@ export default function Home() {
   const selectDirectory = async () => {
     try {
       const handle = await (window as any).showDirectoryPicker()
+      setDirHandle(handle)
       await saveHandle(handle)
       const rawFiles = await readAllFiles(handle)
       const files = filterSystemFiles(rawFiles)
@@ -241,6 +270,7 @@ export default function Home() {
       try {
         const handle = await loadHandle()
         if (handle && (await verifyPermission(handle))) {
+          setDirHandle(handle)
           const raw = await readAllFiles(handle)
           const files = filterSystemFiles(raw)
           setDirFiles(files)
@@ -326,10 +356,11 @@ useEffect(() => {
       const rel = (file as any).webkitRelativePath || ""
       if (rel.split("/").includes("system")) continue
       const parts = rel.split("/") || []
-      if (parts.length >= 5) {
+      if (parts.length >= 4) {
         const weekPart = parts[1]
         const subject = parts[2]
-        const table = parts[3].toLowerCase().includes("pract")
+        const tableBase = parts.length > 4 ? parts[3] : "teoria"
+        const table = tableBase.toLowerCase().includes("pract")
           ? "practice"
           : "theory"
         const week = parseInt(weekPart.replace(/\D/g, ""))
@@ -429,7 +460,8 @@ useEffect(() => {
 
   const toEmbedUrl = (url: string) => {
     try {
-      const u = new URL(url)
+      const clean = url.replace(/["']+$/g, "")
+      const u = new URL(clean)
       if (u.hostname.includes("youtube.com")) {
         const v = u.searchParams.get("v")
         if (v) return `https://www.youtube.com/embed/${v}`
@@ -443,9 +475,9 @@ useEffect(() => {
         const id = u.pathname.slice(1)
         if (id) return `https://www.youtube.com/embed/${id}`
       }
-      return url
+      return clean
     } catch {
-      return url
+      return url.replace(/["']+$/g, "")
     }
   }
 
@@ -467,8 +499,9 @@ useEffect(() => {
       try {
         const buf = await currentPdf.file.arrayBuffer()
         const text = new TextDecoder().decode(buf).replace(/\u0000/g, "")
-        const match = text.match(/https?:\/\/[^\s]+/)
-        const raw = match ? match[0] : null
+        const matches = text.match(/https?:\/\/[^\s"']+/g) || []
+        const raw =
+          matches.find((m) => m.includes("youtube")) || matches[0] || null
         const url = raw ? toEmbedUrl(raw) : null
         setEmbedUrl(url)
       } catch {
@@ -569,8 +602,61 @@ useEffect(() => {
 
   const handleDragLeaveArea = () => setDragCategory(null)
 
-  const handleDropLink = (e: React.DragEvent<HTMLDivElement>) => {
+  const handleDropLink = async (e: React.DragEvent<HTMLDivElement>) => {
     e.preventDefault()
+    const category = dragCategory || 'theory'
+    const dropped = Array.from(e.dataTransfer.files || []).find((f) =>
+      f.name.toLowerCase().endsWith('.lnk'),
+    )
+    if (dropped) {
+      Object.defineProperty(dropped, 'webkitRelativePath', {
+        value: `root/Semana${viewWeek}/${viewSubject}/${category}/${dropped.name}`,
+      })
+      let path = `Semana${viewWeek}/${viewSubject}/${category}/${dropped.name}`
+      try {
+        path = await writeFile(path, dropped)
+      } catch (err) {
+        if (/Name is not allowed/i.test(String(err)) && dropped.name.toLowerCase().endsWith('.lnk')) {
+          const altNameRaw = dropped.name.replace(/\.lnk$/i, '.url')
+          const altName = sanitize(altNameRaw)
+          const alt = new File([await dropped.arrayBuffer()], altName, {
+            type: 'text/plain',
+          })
+          Object.defineProperty(alt, 'webkitRelativePath', {
+            value: `root/Semana${viewWeek}/${viewSubject}/${category}/${altName}`,
+          })
+          path = `Semana${viewWeek}/${viewSubject}/${category}/${altName}`
+          path = await writeFile(path, alt)
+          setDirFiles((prev) => [...prev, alt])
+          const pdf: PdfFile = {
+            file: alt,
+            path,
+            week: viewWeek!,
+            subject: viewSubject!,
+            tableType: category,
+            isPdf: false,
+          }
+          setCurrentPdf(pdf)
+          setDragCategory(null)
+          return
+        }
+        console.warn('Failed to save file', err)
+        setDragCategory(null)
+        return
+      }
+      setDirFiles((prev) => [...prev, dropped])
+      const pdf: PdfFile = {
+        file: dropped,
+        path,
+        week: viewWeek!,
+        subject: viewSubject!,
+        tableType: category,
+        isPdf: false,
+      }
+      setCurrentPdf(pdf)
+      setDragCategory(null)
+      return
+    }
     const data =
       e.dataTransfer.getData('text/uri-list') ||
       e.dataTransfer.getData('text/plain')
@@ -578,21 +664,22 @@ useEffect(() => {
       setDragCategory(null)
       return
     }
-    const category = dragCategory || 'theory'
-    const suggested = data.includes('youtube') ? 'video.lnk' : 'enlace.lnk'
+    const suggested = data.includes('youtube') ? 'video.url' : 'enlace.url'
     const name = prompt('Nombre del enlace:', suggested)
     if (!name) {
       setDragCategory(null)
       return
     }
-    const fileName = name.endsWith('.lnk') ? name : `${name}.lnk`
+    const rawName = name.endsWith('.url') ? name : `${name}.url`
+    const fileName = sanitize(rawName)
     const content = `[InternetShortcut]\nURL=${data}\n`
     const file = new File([content], fileName, { type: 'text/plain' })
     Object.defineProperty(file, 'webkitRelativePath', {
       value: `root/Semana${viewWeek}/${viewSubject}/${category}/${fileName}`,
     })
+    let path = `Semana${viewWeek}/${viewSubject}/${category}/${fileName}`
+    path = await writeFile(path, file)
     setDirFiles((prev) => [...prev, file])
-    const path = `Semana${viewWeek}/${viewSubject}/${category}/${fileName}`
     const pdf: PdfFile = {
       file,
       path,
@@ -745,6 +832,7 @@ useEffect(() => {
                             completed[p.path] ? "line-through text-gray-400" : ""
                           }`}
                         >
+                          <span>{p.isPdf ? "📄" : "🔗"}</span>
                           <span
                             className="flex-1 truncate cursor-pointer"
                             title={p.file.name}
@@ -777,6 +865,7 @@ useEffect(() => {
                             completed[p.path] ? "line-through text-gray-400" : ""
                           }`}
                         >
+                          <span>{p.isPdf ? "📄" : "🔗"}</span>
                           <span
                             className="flex-1 truncate cursor-pointer"
                             title={p.file.name}


### PR DESCRIPTION
## Summary
- include Windows shortcut files when building the file tree so they are listed beside PDFs
- display an icon for link shortcuts to make them easy to spot in the subject view
- allow dropping `.lnk` files and skip unreadable entries when scanning directories
- persist dropped `.lnk` files to disk and request per-file permissions so existing shortcuts load
- sanitize names and fall back to saving `.lnk` drops as `.url` when the browser blocks `.lnk` handles

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive ESLint setup)*
- `npm run build` *(fails: DATABASE_URL no está definido)*

------
https://chatgpt.com/codex/tasks/task_e_68bb42fe579c83308cb541e06e9ee503