### PR TITLE
Allow removing video entries from file list

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -780,6 +780,31 @@ useEffect(() => {
     setOrders({ ...orders, [key]: arr.map((p) => p.path) })
   }
 
+  const removeVideo = (
+    week: number,
+    subject: string,
+    table: 'theory' | 'practice',
+    index: number,
+    path: string,
+  ) => {
+    const v = { ...videos }
+    if (v[week] && v[week][subject]) {
+      const arr = [...v[week][subject][table]]
+      if (index >= 0 && index < arr.length) {
+        arr.splice(index, 1)
+        v[week] = { ...v[week], [subject]: { ...v[week][subject], [table]: arr } }
+        setVideos(v)
+        const key = `${week}-${subject}`
+        if (orders[key]) {
+          setOrders({
+            ...orders,
+            [key]: orders[key].filter((p) => p !== path),
+          })
+        }
+      }
+    }
+  }
+
   const selectedFiles =
     viewWeek && viewSubject ? fileTree[viewWeek]?.[viewSubject] || [] : []
   const theoryFiles = selectedFiles.filter((f) => f.tableType === "theory")
@@ -882,6 +907,21 @@ useEffect(() => {
                           <button onClick={() => reorderPdf(viewWeek!, viewSubject!, idx, 1)}>
                             ↓
                           </button>
+                          {!p.isPdf && (
+                            <button
+                              onClick={() =>
+                                removeVideo(
+                                  p.week,
+                                  p.subject,
+                                  p.tableType,
+                                  parseInt(p.path.split('-').pop() || '0'),
+                                  p.path,
+                                )
+                              }
+                            >
+                              x
+                            </button>
+                          )}
                         </li>
                       )
                     })}
@@ -914,6 +954,21 @@ useEffect(() => {
                           <button onClick={() => reorderPdf(viewWeek!, viewSubject!, idx, 1)}>
                             ↓
                           </button>
+                          {!p.isPdf && (
+                            <button
+                              onClick={() =>
+                                removeVideo(
+                                  p.week,
+                                  p.subject,
+                                  p.tableType,
+                                  parseInt(p.path.split('-').pop() || '0'),
+                                  p.path,
+                                )
+                              }
+                            >
+                              x
+                            </button>
+                          )}
                         </li>
                       )
                     })}


### PR DESCRIPTION
## Summary
- add logic to remove video entries from state and ordering
- show an X button on video items in the file list to delete them

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: requires interactive ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68bc3ea3628c8330a10f418d8242d88f