### PR TITLE
Keep focus mode active after pressing Escape

### DIFF
--- a/public/visor/index.html
+++ b/public/visor/index.html
@@ -766,6 +766,7 @@
       let focusMode = false;
       let focusStart = null;
       let focusPreview = null;
+      let focusCancelTipShown = false;
 
       function updateFocusPreview(e) {
         if (!focusMode || !focusStart || !focusPreview) return;
@@ -1668,8 +1669,11 @@
             focusPreview?.remove();
             focusPreview = null;
             document.removeEventListener('mousemove', updateFocusPreview);
-            showToast('Selección cancelada. Modo enfoque activo ("o" para salir)', 'info');
-            showNavIndicator('Haz dos clics para enfocar');
+            if (!focusCancelTipShown) {
+              showToast('Selección cancelada. Modo enfoque activo ("o" para salir)', 'info');
+              showNavIndicator('Haz dos clics para enfocar');
+              focusCancelTipShown = true;
+            }
           }
           const fo = document.getElementById('focus-overlay');
           if (fo) fo.remove();


### PR DESCRIPTION
## Summary
- allow exiting current focus selection with `Escape` while keeping focus mode enabled
- prompt user to use "o" to exit focus mode and show guidance for selecting

## Testing
- `npm test` *(fails: Missing script: test)*
- `npm run lint` *(prompts for interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68bf3125bb1883308027267e2bfa84c2