### PR TITLE
Keep focus mode active on ESC

### DIFF
--- a/public/visor/index.html
+++ b/public/visor/index.html
@@ -1664,12 +1664,11 @@
             showToast('Captura cancelada', 'info');
           }
           if (focusMode) {
-            focusMode = false;
             focusStart = null;
             focusPreview?.remove();
             focusPreview = null;
             document.removeEventListener('mousemove', updateFocusPreview);
-            showToast('Enfoque cancelado', 'info');
+            showToast('Área enfocada cerrada (modo activo)', 'info');
           }
           const fo = document.getElementById('focus-overlay');
           if (fo) fo.remove();


### PR DESCRIPTION
## Summary
- Allow closing focus area with ESC without exiting focus mode
- Update toast message to clarify that focus mode remains active

## Testing
- `npm test` (fails: Missing script "test")
- `CI=1 npm run lint` (fails: prompts for ESLint configuration)


------
https://chatgpt.com/codex/tasks/task_e_68bf3125bb1883308027267e2bfa84c2