### PR TITLE
Persistir tamaño de fuente en notas temporales

### DIFF
--- a/public/visor/index.html
+++ b/public/visor/index.html
@@ -415,7 +415,7 @@
     }
     .aux-notes-editor {
       flex: 1; padding: 8px; overflow: auto; outline: none;
-      font-size: 14px; line-height: 1.4; color: #333;
+      font-size: 14pt; line-height: 1.4; color: #333;
     }
   </style>
 </head>
@@ -2634,8 +2634,9 @@
       const auxPlus = document.getElementById('aux-font-plus');
       const auxMinus = document.getElementById('aux-font-minus');
       const auxInfo = document.getElementById('aux-notes-info');
-      let auxFontSize = 14;
-      auxEditor.style.fontSize = auxFontSize + 'px';
+      const AUX_FONT_SIZE_KEY = 'aux-note-font-size';
+      let auxFontSize = parseInt(localStorage.getItem(AUX_FONT_SIZE_KEY) || '14', 10);
+      auxEditor.style.fontSize = auxFontSize + 'pt';
       auxBtn.addEventListener('click', () => {
         auxPanel.classList.toggle('hidden');
         if (!auxPanel.classList.contains('hidden')) {
@@ -2644,12 +2645,14 @@
         }
       });
       auxPlus.addEventListener('click', () => {
-        auxFontSize = Math.min(40, auxFontSize + 2);
-        auxEditor.style.fontSize = auxFontSize + 'px';
+        auxFontSize = Math.min(100, auxFontSize + 2);
+        auxEditor.style.fontSize = auxFontSize + 'pt';
+        localStorage.setItem(AUX_FONT_SIZE_KEY, String(auxFontSize));
       });
       auxMinus.addEventListener('click', () => {
-        auxFontSize = Math.max(10, auxFontSize - 2);
-        auxEditor.style.fontSize = auxFontSize + 'px';
+        auxFontSize = Math.max(1, auxFontSize - 2);
+        auxEditor.style.fontSize = auxFontSize + 'pt';
+        localStorage.setItem(AUX_FONT_SIZE_KEY, String(auxFontSize));
       });
       auxInfo.addEventListener('click', () => {
         alert('Editor de fórmulas basado en MathQuill');


### PR DESCRIPTION
## Summary
- Guarda el tamaño de letra del editor de notas temporales y lo restaura en futuras sesiones
- Limita el tamaño máximo a 100pt y usa unidades pt para el editor

## Testing
- `npm test` *(falla: Missing script "test")*
- `npm run lint` *(requiere configuración interactiva de ESLint)*

------
https://chatgpt.com/codex/tasks/task_e_68bf6bee1f94833089667f3ba385337a