### PR TITLE
Recordar último archivo y botón de inicio

### DIFF
--- a/public/visor/index.html
+++ b/public/visor/index.html
@@ -669,6 +669,12 @@
             scheduleRender(p);
           }
           localStorage.setItem('lastPage-' + currentPdfKey, String(p));
+          try {
+            window.parent.postMessage(
+              { type: 'viewerPage', page: p, key: currentPdfKey },
+              '*'
+            );
+          } catch {}
         }
       });
 
@@ -2681,8 +2687,9 @@
       const params = new URLSearchParams(window.location.search);
       const urlParam = params.get('url');
       const nameParam = params.get('name');
+      const keyParam = params.get('key');
       if (urlParam && nameParam) {
-        loadPdf(urlParam, nameParam);
+        loadPdf(urlParam, nameParam, keyParam || '');
       }
 
       // ========================================


### PR DESCRIPTION
## Resumen
- Guardar y restaurar el último PDF o video seleccionado
- Añadir botones de Inicio en la vista y el visor
- Enviar página actual al componente principal

## Pruebas
- `npm test` *(falla: Missing script)*
- `npm run lint` *(falla: requiere configuración interactiva)*

------
https://chatgpt.com/codex/tasks/task_e_68bf6eb1701c8330b8a7ef2c7542dbf0