### PR TITLE
Fix last file tracking in viewer

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -588,12 +588,12 @@ useEffect(() => {
 
   // remember last opened file
   useEffect(() => {
-    if (currentPdf) {
+    if (currentPdf && restored) {
       localStorage.setItem('lastPath', currentPdf.path)
       localStorage.setItem('lastWeek', String(currentPdf.week))
       localStorage.setItem('lastSubject', currentPdf.subject)
     }
-  }, [currentPdf])
+  }, [currentPdf, restored])
 
   // listen for messages from the PDF viewer
   useEffect(() => {


### PR DESCRIPTION
## Summary
- avoid overwriting stored last path until it has been restored

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: requires interactive configuration)

------
https://chatgpt.com/codex/tasks/task_e_68c176a7d948833083f322337067d8ef