### PR TITLE
Add PDF viewing timer with daily tracking

### DIFF
--- a/app/api/time/route.ts
+++ b/app/api/time/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getPool } from "@/lib/db";
+
+export const runtime = "nodejs";
+
+const pool = getPool();
+
+export async function POST(req: NextRequest) {
+  try {
+    const { date, weekday, minutes } = await req.json();
+    if (
+      typeof date !== "string" ||
+      typeof weekday !== "string" ||
+      typeof minutes !== "number"
+    ) {
+      return NextResponse.json({ error: "Invalid body" }, { status: 400 });
+    }
+
+    await pool.query(
+      `INSERT INTO daily_time (date, weekday, minutes)
+       VALUES ($1::date, $2::text, $3::int)
+       ON CONFLICT (date) DO UPDATE SET weekday = EXCLUDED.weekday, minutes = EXCLUDED.minutes;`,
+      [date, weekday, minutes]
+    );
+
+    return NextResponse.json({ ok: true });
+  } catch (err: any) {
+    console.error(err);
+    return NextResponse.json(
+      {
+        error: "Internal Server Error",
+        message: err?.message || String(err),
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/public/visor/index.html
+++ b/public/visor/index.html
@@ -57,6 +57,10 @@
     body.light-mode .header-center { color: #202124; }
     .header-right { display: flex; align-items: center; gap: 8px; }
 
+    #session-timer, #today-time { font-variant-numeric: tabular-nums; }
+    #session-timer { margin-left: 8px; }
+    #today-time { margin-left: 16px; font-size: 13px; }
+
     .control-btn {
       background: transparent; border: none; color: #e8eaed;
       padding: 8px; border-radius: 4px; cursor: pointer; font-size: 14px;
@@ -436,9 +440,12 @@
     <div class="header-left">
       <button class="control-btn" id="back-btn" disabled>← Atrás</button>
     </div>
-    <div class="header-center" id="file-info">Visor PDF</div>
+    <div class="header-center" id="file-info">
+      <span id="file-name">Visor PDF</span>
+      <span id="session-timer">00:00</span>
+    </div>
     <div class="header-right">
-       NUEVOS: carpeta de PDFs e iniciar 
+       NUEVOS: carpeta de PDFs e iniciar
       <button class="control-btn" id="pdf-folder-btn" title="Seleccionar carpeta de PDFs">📂 PDFs</button>
       <button class="control-btn" id="start-btn" title="Abrir primer PDF" disabled>▶ iniciar →</button>
       <input type="file" id="pdf-folder-input" class="hidden" style="display:none"
@@ -456,6 +463,7 @@
 
       <button class="control-btn" id="theme-toggle" title="Cambiar tema">🌙</button>
       <button class="control-btn" id="info-btn" title="Ayuda">ℹ️</button>
+      <div id="today-time">Hoy: 00:00</div>
     </div>
   </header>
 
@@ -663,7 +671,9 @@
       const dropZone = document.getElementById('drop-zone');
       const uploadArea = document.getElementById('upload-area');
       const fileInput = document.getElementById('file-input');
-      const fileInfo = document.getElementById('file-info');
+      const fileNameEl = document.getElementById('file-name');
+      const sessionTimerEl = document.getElementById('session-timer');
+      const todayTimeEl = document.getElementById('today-time');
       const fullscreenBtn = document.getElementById('fullscreen-btn');
       const backBtn = document.getElementById('back-btn');
       let navIndicator = document.getElementById('nav-indicator');
@@ -672,6 +682,93 @@
       // Overlay de carga
       let loadingOverlay = document.getElementById('loading-overlay');
       let loadingText = document.getElementById('loading-text');
+
+      let timerInterval = null;
+      let timerRunning = false;
+      let sessionStart = 0;
+      let sessionElapsed = 0;
+      let todayElapsed = 0;
+      let todayDate = new Date().toISOString().slice(0,10);
+      const storedDaily = localStorage.getItem('dailyTime');
+      if (storedDaily) {
+        try {
+          const parsed = JSON.parse(storedDaily);
+          if (parsed.date === todayDate) {
+            todayElapsed = parsed.ms || 0;
+          }
+        } catch {}
+      }
+
+      function formatTime(ms) {
+        const totalMin = Math.floor(ms / 60000);
+        const h = String(Math.floor(totalMin / 60)).padStart(2, '0');
+        const m = String(totalMin % 60).padStart(2, '0');
+        return `${h}:${m}`;
+      }
+
+      function updateSessionDisplay() {
+        const ms = timerRunning ? sessionElapsed + (Date.now() - sessionStart) : sessionElapsed;
+        sessionTimerEl.textContent = formatTime(ms);
+      }
+
+      function updateTodayDisplay() {
+        todayTimeEl.textContent = 'Hoy: ' + formatTime(todayElapsed);
+      }
+
+      function saveDaily() {
+        localStorage.setItem('dailyTime', JSON.stringify({ date: todayDate, ms: todayElapsed }));
+      }
+
+      async function sendDaily() {
+        try {
+          const weekdayNames = ['domingo','lunes','martes','miércoles','jueves','viernes','sábado'];
+          await fetch('/api/time', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ date: todayDate, weekday: weekdayNames[new Date().getDay()], minutes: Math.floor(todayElapsed/60000) })
+          });
+        } catch {}
+      }
+
+      function startSessionTimer() {
+        if (timerRunning) return;
+        timerRunning = true;
+        sessionStart = Date.now();
+        timerInterval = setInterval(updateSessionDisplay, 1000);
+      }
+
+      function pauseSessionTimer() {
+        if (!timerRunning) return;
+        const delta = Date.now() - sessionStart;
+        sessionElapsed += delta;
+        todayElapsed += delta;
+        timerRunning = false;
+        clearInterval(timerInterval);
+        updateSessionDisplay();
+        updateTodayDisplay();
+        saveDaily();
+        void sendDaily();
+      }
+
+      function resetSessionTimer() {
+        pauseSessionTimer();
+        sessionElapsed = 0;
+        updateSessionDisplay();
+      }
+
+      updateSessionDisplay();
+      updateTodayDisplay();
+
+      document.addEventListener('keydown', (e) => {
+        if (e.key.toLowerCase() === 'c') {
+          e.preventDefault();
+          timerRunning ? pauseSessionTimer() : startSessionTimer();
+        }
+      });
+
+      document.addEventListener('visibilitychange', () => {
+        if (document.hidden) pauseSessionTimer();
+      });
 
       container.addEventListener('scroll', () => {
         if (currentPdfKey) {
@@ -1140,7 +1237,8 @@
 
           dropZone.classList.add('hidden');
           backBtn.disabled = false;
-          fileInfo.textContent = filename;
+          fileNameEl.textContent = filename;
+          resetSessionTimer();
           currentPdfName = filename;
           currentPdfKey = uniqueKey ? `${filename}-${uniqueKey}` : filename;
           drawMode = true;
@@ -1177,7 +1275,8 @@
 
           dropZone.classList.remove('hidden');
           backBtn.disabled = true;
-          fileInfo.textContent = 'Visor PDF';
+          fileNameEl.textContent = 'Visor PDF';
+          resetSessionTimer();
           currentPdfName = null;
           currentPdfKey = null;
           hideOverlay();
@@ -1395,7 +1494,8 @@
       backBtn.addEventListener('click', () => {
         dropZone.classList.remove('hidden');
         clearContainer();
-        fileInfo.textContent = 'Visor PDF';
+        fileNameEl.textContent = 'Visor PDF';
+        resetSessionTimer();
         backBtn.disabled = true;
         pdfDoc = null;
         hidePopup();

--- a/scripts/create_daily_time.sql
+++ b/scripts/create_daily_time.sql
@@ -1,0 +1,5 @@
+CREATE TABLE IF NOT EXISTS daily_time (
+  date DATE PRIMARY KEY,
+  weekday TEXT NOT NULL,
+  minutes INTEGER NOT NULL DEFAULT 0
+);


### PR DESCRIPTION
## Summary
- show per-PDF session timer next to file name and daily total at toolbar right
- start/pause timer with the `c` key and auto-pause when tab hidden
- record daily viewing minutes to `daily_time` table via new `/api/time`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1d995282c833092262396e67fa584