### PR TITLE
Add PDF viewing timers with daily tracking

### DIFF
--- a/app/api/time/route.ts
+++ b/app/api/time/route.ts
@@ -1,0 +1,57 @@
+import { NextResponse } from "next/server"
+import { getPool } from "@/lib/db"
+
+const pool = getPool()
+
+export async function GET() {
+  try {
+    await pool.query(`
+      CREATE TABLE IF NOT EXISTS daily_time (
+        date DATE PRIMARY KEY,
+        day_of_week TEXT NOT NULL,
+        seconds_total INTEGER NOT NULL DEFAULT 0
+      )
+    `)
+    const today = new Date().toISOString().split('T')[0]
+    const { rows } = await pool.query(
+      'SELECT seconds_total FROM daily_time WHERE date=$1',
+      [today],
+    )
+    const seconds = rows[0]?.seconds_total ?? 0
+    return NextResponse.json({ seconds })
+  } catch (err) {
+    console.error('/api/time GET', err)
+    return NextResponse.json({ error: 'db error' }, { status: 500 })
+  }
+}
+
+export async function POST(req: Request) {
+  try {
+    const { seconds } = await req.json()
+    if (!seconds || seconds <= 0) {
+      return NextResponse.json({ seconds: 0 })
+    }
+    await pool.query(`
+      CREATE TABLE IF NOT EXISTS daily_time (
+        date DATE PRIMARY KEY,
+        day_of_week TEXT NOT NULL,
+        seconds_total INTEGER NOT NULL DEFAULT 0
+      )
+    `)
+    const now = new Date()
+    const date = now.toISOString().split('T')[0]
+    const day = now.toLocaleDateString('es-ES', { weekday: 'long' })
+    const upsert = `
+      INSERT INTO daily_time (date, day_of_week, seconds_total)
+      VALUES ($1, $2, $3)
+      ON CONFLICT (date)
+      DO UPDATE SET seconds_total = daily_time.seconds_total + EXCLUDED.seconds_total
+      RETURNING seconds_total;
+    `
+    const { rows } = await pool.query(upsert, [date, day, seconds])
+    return NextResponse.json({ seconds: rows[0].seconds_total })
+  } catch (err) {
+    console.error('/api/time POST', err)
+    return NextResponse.json({ error: 'db error' }, { status: 500 })
+  }
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect, useRef, useState } from "react"
+import { useCallback, useEffect, useRef, useState } from "react"
 import { useTheme } from "next-themes"
 
 const days = ["Lunes", "Martes", "Miércoles", "Jueves", "Viernes"]
@@ -121,12 +121,114 @@ export default function Home() {
   const [darkModeStart, setDarkModeStart] = useState(19)
   const [configFound, setConfigFound] = useState<boolean | null>(null)
   const [canonicalSubjects, setCanonicalSubjects] = useState<string[]>([])
+  const [timerRunning, setTimerRunning] = useState(false)
+  const [elapsedSeconds, setElapsedSeconds] = useState(0)
+  const [todaySeconds, setTodaySeconds] = useState(0)
+  const [currentDate, setCurrentDate] = useState(
+    new Date().toISOString().split('T')[0],
+  )
   const viewerRef = useRef<HTMLIFrameElement>(null)
   const [toast, setToast] = useState<{ type: 'success' | 'error'; text: string } | null>(null)
   const toastTimerRef = useRef<number | null>(null)
   const [restored, setRestored] = useState(false)
   // Avoid hydration mismatch: render only after mounted
   const [mounted, setMounted] = useState(false)
+
+  const formatTime = (sec: number) => {
+    const h = Math.floor(sec / 3600)
+      .toString()
+      .padStart(2, '0')
+    const m = Math.floor((sec % 3600) / 60)
+      .toString()
+      .padStart(2, '0')
+    return `${h}:${m}`
+  }
+
+  const sendTime = async (sec: number) => {
+    if (sec <= 0) return
+    try {
+      const res = await fetch('/api/time', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ seconds: sec }),
+      })
+      const data = await res.json()
+      if (typeof data.seconds === 'number') {
+        setTodaySeconds(data.seconds)
+      }
+    } catch (err) {
+      console.error('sendTime error', err)
+    }
+  }
+
+  const pauseTimer = useCallback(() => {
+    setTimerRunning(false)
+    if (elapsedSeconds > 0) {
+      sendTime(elapsedSeconds)
+      setElapsedSeconds(0)
+    }
+  }, [elapsedSeconds])
+
+  useEffect(() => {
+    const fetchToday = async () => {
+      try {
+        const res = await fetch('/api/time')
+        const data = await res.json()
+        if (typeof data.seconds === 'number') setTodaySeconds(data.seconds)
+      } catch (err) {
+        console.error('fetchToday error', err)
+      }
+    }
+    fetchToday()
+  }, [])
+
+  useEffect(() => {
+    if (!timerRunning || document.visibilityState !== 'visible') return
+    const id = window.setInterval(() => {
+      setElapsedSeconds((s) => s + 1)
+      setTodaySeconds((s) => s + 1)
+    }, 1000)
+    return () => window.clearInterval(id)
+  }, [timerRunning])
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key.toLowerCase() === 'c' && viewerOpen) {
+        e.preventDefault()
+        if (timerRunning) {
+          pauseTimer()
+        } else {
+          const todayStr = new Date().toISOString().split('T')[0]
+          if (todayStr !== currentDate) {
+            setCurrentDate(todayStr)
+            setTodaySeconds(0)
+          }
+          setTimerRunning(true)
+        }
+      }
+    }
+    window.addEventListener('keydown', handler)
+    const frame = viewerRef.current?.contentWindow
+    frame?.addEventListener('keydown', handler, { capture: true })
+    return () => {
+      window.removeEventListener('keydown', handler)
+      frame?.removeEventListener('keydown', handler, { capture: true })
+    }
+  }, [viewerOpen, timerRunning, currentDate, pauseTimer])
+
+  useEffect(() => {
+    const vis = () => {
+      if (document.visibilityState !== 'visible' && timerRunning) {
+        pauseTimer()
+      }
+    }
+    document.addEventListener('visibilitychange', vis)
+    return () => document.removeEventListener('visibilitychange', vis)
+  }, [timerRunning, pauseTimer])
+
+  useEffect(() => {
+    if (!viewerOpen && timerRunning) pauseTimer()
+  }, [viewerOpen, timerRunning, pauseTimer])
 
   const applyTheme = (start: number) => {
     const hour = new Date().getHours()
@@ -1065,9 +1167,12 @@ useEffect(() => {
           {viewerOpen ? (
             !pdfFullscreen && (
               <div className="flex flex-wrap items-center justify-between p-2 border-b gap-2">
-                <span className="truncate" title={currentPdf?.file.name}>
-                  {currentPdf?.file.name}
-                </span>
+                <div className="flex items-center gap-2">
+                  <span className="truncate" title={currentPdf?.file.name}>
+                    {currentPdf?.file.name}
+                  </span>
+                  <span>{formatTime(elapsedSeconds)}</span>
+                </div>
                 <div className="flex flex-wrap items-center gap-2">
                   <button
                     onClick={() => {
@@ -1115,6 +1220,7 @@ useEffect(() => {
                   >
                     ✕
                   </button>
+                  <span>Hoy: {formatTime(todaySeconds)}</span>
                 </div>
               </div>
             )

--- a/public/visor/index.html
+++ b/public/visor/index.html
@@ -2713,7 +2713,7 @@
         document.querySelectorAll('.draw-canvas').forEach(canvas => {
           const data = localStorage.getItem(`drawing-${currentPdfKey}-page${canvas.dataset.page}`);
           if (data) {
-            const ctx = canvas.getContext('2d');
+            const ctx = canvas.getContext('2d', { willReadFrequently: true });
             const img = new Image();
             img.onload = () => ctx.drawImage(img,0,0,canvas.width,canvas.height);
             img.src = data;
@@ -2728,7 +2728,7 @@
       function clearAllDrawings() {
         if (!currentPdfKey) return;
         document.querySelectorAll('.draw-canvas').forEach(canvas => {
-          const ctx = canvas.getContext('2d');
+          const ctx = canvas.getContext('2d', { willReadFrequently: true });
           ctx.clearRect(0, 0, canvas.width, canvas.height);
           canvas._history = [];
           localStorage.removeItem(`drawing-${currentPdfKey}-page${canvas.dataset.page}`);
@@ -2739,7 +2739,7 @@
         if (!drawMode) return;
         isDrawing = true;
         const canvas = e.target;
-        const ctx = canvas.getContext('2d');
+        const ctx = canvas.getContext('2d', { willReadFrequently: true });
         ctx.globalCompositeOperation = eraseMode ? 'destination-out' : 'source-over';
         ctx.strokeStyle = eraseMode ? 'rgba(0,0,0,1)' : brushColor;
         ctx.lineWidth = brushWidth;
@@ -2777,7 +2777,7 @@
 
       function undoLastStroke() {
         if (!currentCanvas || !currentCanvas._history || !currentCanvas._history.length) return;
-        const ctx = currentCanvas.getContext('2d');
+        const ctx = currentCanvas.getContext('2d', { willReadFrequently: true });
         const imageData = currentCanvas._history.pop();
         ctx.putImageData(imageData, 0, 0);
         saveDrawing(currentCanvas);


### PR DESCRIPTION
## Summary
- track PDF viewing time with per-document timer
- show cumulative time spent today and store in Postgres
- capture "c" key presses inside the PDF iframe to start/stop timers reliably
- mark drawing canvases as `willReadFrequently` to avoid Canvas warnings

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(prompts for ESLint configuration and exits)*


------
https://chatgpt.com/codex/tasks/task_e_68c1d995282c833092262396e67fa584