### PR TITLE
Add PDF viewing timers with daily tracking

### DIFF
--- a/app/api/time/route.ts
+++ b/app/api/time/route.ts
@@ -1,0 +1,57 @@
+import { NextResponse } from "next/server"
+import { getPool } from "@/lib/db"
+
+const pool = getPool()
+
+export async function GET() {
+  try {
+    await pool.query(`
+      CREATE TABLE IF NOT EXISTS daily_time (
+        date DATE PRIMARY KEY,
+        day_of_week TEXT NOT NULL,
+        seconds_total INTEGER NOT NULL DEFAULT 0
+      )
+    `)
+    const today = new Date().toISOString().split('T')[0]
+    const { rows } = await pool.query(
+      'SELECT seconds_total FROM daily_time WHERE date=$1',
+      [today],
+    )
+    const seconds = rows[0]?.seconds_total ?? 0
+    return NextResponse.json({ seconds })
+  } catch (err) {
+    console.error('/api/time GET', err)
+    return NextResponse.json({ error: 'db error' }, { status: 500 })
+  }
+}
+
+export async function POST(req: Request) {
+  try {
+    const { seconds } = await req.json()
+    if (!seconds || seconds <= 0) {
+      return NextResponse.json({ seconds: 0 })
+    }
+    await pool.query(`
+      CREATE TABLE IF NOT EXISTS daily_time (
+        date DATE PRIMARY KEY,
+        day_of_week TEXT NOT NULL,
+        seconds_total INTEGER NOT NULL DEFAULT 0
+      )
+    `)
+    const now = new Date()
+    const date = now.toISOString().split('T')[0]
+    const day = now.toLocaleDateString('es-ES', { weekday: 'long' })
+    const upsert = `
+      INSERT INTO daily_time (date, day_of_week, seconds_total)
+      VALUES ($1, $2, $3)
+      ON CONFLICT (date)
+      DO UPDATE SET seconds_total = daily_time.seconds_total + EXCLUDED.seconds_total
+      RETURNING seconds_total;
+    `
+    const { rows } = await pool.query(upsert, [date, day, seconds])
+    return NextResponse.json({ seconds: rows[0].seconds_total })
+  } catch (err) {
+    console.error('/api/time POST', err)
+    return NextResponse.json({ error: 'db error' }, { status: 500 })
+  }
+}

--- a/public/visor/index.html
+++ b/public/visor/index.html
@@ -631,6 +631,11 @@
           toggleTheme();
         } else if (e.data.type === 'toggleFullscreen') {
           toggleFullscreen();
+        } else if (e.data.type === 'timerStatus') {
+          showToast(
+            e.data.running ? 'Cronómetro iniciado' : 'Cronómetro pausado',
+            'info',
+          );
         }
       });
 
@@ -658,6 +663,14 @@
           e.preventDefault();
           zoomLevel = 1;
           applyZoom();
+        }
+      });
+      document.addEventListener('keydown', (e) => {
+        if (e.key.toLowerCase() === 'c') {
+          try {
+            window.parent.postMessage({ type: 'toggleTimer' }, '*');
+            e.preventDefault();
+          } catch {}
         }
       });
       const dropZone = document.getElementById('drop-zone');


### PR DESCRIPTION
## Summary
- track PDF viewing time with per-document timer
- show cumulative time spent today and store in Postgres
- allow pressing "c" inside PDF viewer to toggle timer
- display per-PDF timer with seconds and notify on start/pause

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d995282c833092262396e67fa584