### PR TITLE
Add PDF viewing timers with daily tracking

### DIFF
--- a/app/api/time/route.ts
+++ b/app/api/time/route.ts
@@ -1,0 +1,57 @@
+import { NextResponse } from "next/server"
+import { getPool } from "@/lib/db"
+
+const pool = getPool()
+
+export async function GET() {
+  try {
+    await pool.query(`
+      CREATE TABLE IF NOT EXISTS daily_time (
+        date DATE PRIMARY KEY,
+        day_of_week TEXT NOT NULL,
+        seconds_total INTEGER NOT NULL DEFAULT 0
+      )
+    `)
+    const today = new Date().toISOString().split('T')[0]
+    const { rows } = await pool.query(
+      'SELECT seconds_total FROM daily_time WHERE date=$1',
+      [today],
+    )
+    const seconds = rows[0]?.seconds_total ?? 0
+    return NextResponse.json({ seconds })
+  } catch (err) {
+    console.error('/api/time GET', err)
+    return NextResponse.json({ error: 'db error' }, { status: 500 })
+  }
+}
+
+export async function POST(req: Request) {
+  try {
+    const { seconds } = await req.json()
+    if (!seconds || seconds <= 0) {
+      return NextResponse.json({ seconds: 0 })
+    }
+    await pool.query(`
+      CREATE TABLE IF NOT EXISTS daily_time (
+        date DATE PRIMARY KEY,
+        day_of_week TEXT NOT NULL,
+        seconds_total INTEGER NOT NULL DEFAULT 0
+      )
+    `)
+    const now = new Date()
+    const date = now.toISOString().split('T')[0]
+    const day = now.toLocaleDateString('es-ES', { weekday: 'long' })
+    const upsert = `
+      INSERT INTO daily_time (date, day_of_week, seconds_total)
+      VALUES ($1, $2, $3)
+      ON CONFLICT (date)
+      DO UPDATE SET seconds_total = daily_time.seconds_total + EXCLUDED.seconds_total
+      RETURNING seconds_total;
+    `
+    const { rows } = await pool.query(upsert, [date, day, seconds])
+    return NextResponse.json({ seconds: rows[0].seconds_total })
+  } catch (err) {
+    console.error('/api/time POST', err)
+    return NextResponse.json({ error: 'db error' }, { status: 500 })
+  }
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect, useRef, useState } from "react"
+import { useCallback, useEffect, useRef, useState } from "react"
 import { useTheme } from "next-themes"
 
 const days = ["Lunes", "Martes", "Miércoles", "Jueves", "Viernes"]
@@ -121,12 +121,171 @@ export default function Home() {
   const [darkModeStart, setDarkModeStart] = useState(19)
   const [configFound, setConfigFound] = useState<boolean | null>(null)
   const [canonicalSubjects, setCanonicalSubjects] = useState<string[]>([])
+  const [timerRunning, setTimerRunning] = useState(false)
+  const [elapsedSeconds, setElapsedSeconds] = useState(0)
+  const [unsentSeconds, setUnsentSeconds] = useState(0)
+  const [todaySeconds, setTodaySeconds] = useState(0)
+  const [currentDate, setCurrentDate] = useState(
+    new Date().toISOString().split('T')[0],
+  )
   const viewerRef = useRef<HTMLIFrameElement>(null)
   const [toast, setToast] = useState<{ type: 'success' | 'error'; text: string } | null>(null)
   const toastTimerRef = useRef<number | null>(null)
+  const wasRunningRef = useRef(false)
   const [restored, setRestored] = useState(false)
   // Avoid hydration mismatch: render only after mounted
   const [mounted, setMounted] = useState(false)
+
+  const formatHM = (sec: number) => {
+    const h = Math.floor(sec / 3600)
+      .toString()
+      .padStart(2, '0')
+    const m = Math.floor((sec % 3600) / 60)
+      .toString()
+      .padStart(2, '0')
+    return `${h}:${m}`
+  }
+
+  const formatHMS = (sec: number) => {
+    const h = Math.floor(sec / 3600)
+      .toString()
+      .padStart(2, '0')
+    const m = Math.floor((sec % 3600) / 60)
+      .toString()
+      .padStart(2, '0')
+    const s = Math.floor(sec % 60)
+      .toString()
+      .padStart(2, '0')
+    return `${h}:${m}:${s}`
+  }
+
+  const sendTime = async (sec: number) => {
+    if (sec <= 0) return
+    try {
+      const res = await fetch('/api/time', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ seconds: sec }),
+      })
+      const data = await res.json()
+      if (typeof data.seconds === 'number') {
+        setTodaySeconds(data.seconds)
+      }
+    } catch (err) {
+      console.error('sendTime error', err)
+    }
+  }
+
+  const pauseTimer = useCallback(() => {
+    setTimerRunning(false)
+    if (unsentSeconds > 0) {
+      sendTime(unsentSeconds)
+      setUnsentSeconds(0)
+    }
+  }, [unsentSeconds])
+
+  const resumeTimer = useCallback(() => {
+    const todayStr = new Date().toISOString().split('T')[0]
+    if (todayStr !== currentDate) {
+      setCurrentDate(todayStr)
+      setTodaySeconds(0)
+    }
+    setTimerRunning(true)
+  }, [currentDate])
+
+  const toggleTimer = useCallback(() => {
+    if (timerRunning) {
+      pauseTimer()
+      setToast({ type: 'success', text: 'Cronómetro pausado' })
+    } else {
+      const todayStr = new Date().toISOString().split('T')[0]
+      if (todayStr !== currentDate) {
+        setCurrentDate(todayStr)
+        setTodaySeconds(0)
+      }
+      setTimerRunning(true)
+      setToast({ type: 'success', text: 'Cronómetro iniciado' })
+    }
+    if (toastTimerRef.current) window.clearTimeout(toastTimerRef.current)
+    toastTimerRef.current = window.setTimeout(() => setToast(null), 3000)
+  }, [timerRunning, pauseTimer, currentDate])
+
+  useEffect(() => {
+    const fetchToday = async () => {
+      try {
+        const res = await fetch('/api/time')
+        const data = await res.json()
+        if (typeof data.seconds === 'number') setTodaySeconds(data.seconds)
+      } catch (err) {
+        console.error('fetchToday error', err)
+      }
+    }
+    fetchToday()
+  }, [])
+
+  useEffect(() => {
+    if (!timerRunning || document.visibilityState !== 'visible') return
+    const id = window.setInterval(() => {
+      setElapsedSeconds((s) => s + 1)
+      setTodaySeconds((s) => s + 1)
+      setUnsentSeconds((s) => s + 1)
+    }, 1000)
+    return () => window.clearInterval(id)
+  }, [timerRunning])
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key.toLowerCase() === 'c' && viewerOpen) {
+        e.preventDefault()
+        toggleTimer()
+      }
+    }
+    window.addEventListener('keydown', handler)
+    return () => window.removeEventListener('keydown', handler)
+  }, [viewerOpen, toggleTimer])
+
+  useEffect(() => {
+    const handler = (e: MessageEvent) => {
+      if (e.data?.type === 'toggleTimer' && viewerOpen) {
+        toggleTimer()
+      }
+    }
+    window.addEventListener('message', handler)
+    return () => window.removeEventListener('message', handler)
+  }, [viewerOpen, toggleTimer])
+
+  useEffect(() => {
+    const vis = () => {
+      if (document.visibilityState === 'hidden') {
+        if (timerRunning) {
+          wasRunningRef.current = true
+          pauseTimer()
+        }
+      } else if (document.visibilityState === 'visible') {
+        if (wasRunningRef.current) {
+          wasRunningRef.current = false
+          resumeTimer()
+        }
+      }
+    }
+    document.addEventListener('visibilitychange', vis)
+    return () => document.removeEventListener('visibilitychange', vis)
+  }, [timerRunning, pauseTimer, resumeTimer])
+
+  useEffect(() => {
+    if (!viewerOpen) {
+      if (timerRunning) pauseTimer()
+      setElapsedSeconds(0)
+      setUnsentSeconds(0)
+    }
+  }, [viewerOpen, timerRunning, pauseTimer])
+
+  useEffect(() => {
+    viewerRef.current?.contentWindow?.postMessage(
+      { type: 'setTheme', theme },
+      '*',
+    )
+  }, [theme, viewerOpen])
 
   const applyTheme = (start: number) => {
     const hour = new Date().getHours()
@@ -653,6 +812,9 @@ useEffect(() => {
   }
 
   const handleSelectFile = (pdf: PdfFile) => {
+    if (timerRunning) pauseTimer()
+    setElapsedSeconds(0)
+    setUnsentSeconds(0)
     const idx = queue.findIndex((f) => f.path === pdf.path)
     if (idx >= 0) {
       setQueueIndex(idx)
@@ -665,6 +827,9 @@ useEffect(() => {
 
   const prevPdf = () => {
     if (queueIndex > 0) {
+      if (timerRunning) pauseTimer()
+      setElapsedSeconds(0)
+      setUnsentSeconds(0)
       const i = queueIndex - 1
       setQueueIndex(i)
       setCurrentPdf(queue[i])
@@ -674,6 +839,9 @@ useEffect(() => {
 
   const nextPdf = () => {
     if (queueIndex < queue.length - 1) {
+      if (timerRunning) pauseTimer()
+      setElapsedSeconds(0)
+      setUnsentSeconds(0)
       const i = queueIndex + 1
       setQueueIndex(i)
       setCurrentPdf(queue[i])
@@ -1065,9 +1233,12 @@ useEffect(() => {
           {viewerOpen ? (
             !pdfFullscreen && (
               <div className="flex flex-wrap items-center justify-between p-2 border-b gap-2">
-                <span className="truncate" title={currentPdf?.file.name}>
-                  {currentPdf?.file.name}
-                </span>
+                <div className="flex items-center gap-2">
+                  <span className="truncate" title={currentPdf?.file.name}>
+                    {currentPdf?.file.name}
+                  </span>
+                  <span>{formatHMS(elapsedSeconds)}</span>
+                </div>
                 <div className="flex flex-wrap items-center gap-2">
                   <button
                     onClick={() => {
@@ -1095,10 +1266,6 @@ useEffect(() => {
                   <button
                     onClick={() => {
                       setTheme(theme === 'light' ? 'dark' : 'light')
-                      viewerRef.current?.contentWindow?.postMessage(
-                        { type: 'toggleTheme' },
-                        '*'
-                      )
                     }}
                   >
                     {theme === 'light' ? '🌞' : '🌙'}
@@ -1115,6 +1282,7 @@ useEffect(() => {
                   >
                     ✕
                   </button>
+                  <span>Hoy: {formatHM(todaySeconds)}</span>
                 </div>
               </div>
             )
@@ -1151,6 +1319,12 @@ useEffect(() => {
             {currentPdf && (pdfUrl || embedUrl) ? (
               <iframe
                 ref={viewerRef}
+                onLoad={() =>
+                  viewerRef.current?.contentWindow?.postMessage(
+                    { type: 'setTheme', theme },
+                    '*',
+                  )
+                }
                 title={viewerOpen ? (currentPdf.isPdf ? 'Visor PDF' : 'Visor') : 'Previsualización'}
                 src={
                   currentPdf.isPdf

--- a/public/visor/index.html
+++ b/public/visor/index.html
@@ -629,6 +629,15 @@
           applyZoom();
         } else if (e.data.type === 'toggleTheme') {
           toggleTheme();
+        } else if (e.data.type === 'setTheme') {
+          if (e.data.theme === 'light') {
+            document.body.classList.add('light-mode');
+          } else {
+            document.body.classList.remove('light-mode');
+          }
+          if (themeToggleBtn) {
+            themeToggleBtn.textContent = document.body.classList.contains('light-mode') ? '🌞' : '🌙';
+          }
         } else if (e.data.type === 'toggleFullscreen') {
           toggleFullscreen();
         }
@@ -658,6 +667,14 @@
           e.preventDefault();
           zoomLevel = 1;
           applyZoom();
+        }
+      });
+      document.addEventListener('keydown', (e) => {
+        if (e.key.toLowerCase() === 'c') {
+          try {
+            window.parent.postMessage({ type: 'toggleTimer' }, '*');
+            e.preventDefault();
+          } catch {}
         }
       });
       const dropZone = document.getElementById('drop-zone');
@@ -726,18 +743,6 @@
           themeToggleBtn.textContent = document.body.classList.contains('light-mode') ? '🌞' : '🌙';
         }
       }
-      function applyAutoTheme() {
-        const hour = new Date().getHours();
-        if (hour >= 6 && hour < 18) {
-          document.body.classList.add('light-mode');
-        } else {
-          document.body.classList.remove('light-mode');
-        }
-        if (themeToggleBtn) {
-          themeToggleBtn.textContent = document.body.classList.contains('light-mode') ? '🌞' : '🌙';
-        }
-      }
-      applyAutoTheme();
       themeToggleBtn?.addEventListener('click', toggleTheme);
 
       // Persistencia de notas


### PR DESCRIPTION
## Summary
- track PDF viewing time with per-document timer
- show cumulative time spent today and store in Postgres
- allow pressing "c" inside PDF viewer to toggle timer
- display seconds on per-document timer and show toast when starting or pausing
- preserve timer value when paused and sync viewer theme with app's day/night mode
- auto-resume timer when returning to tab

## Testing
- `npm test` *(fails: Missing script "test")*
- `CI=true npm run lint` *(aborted: requires interactive ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d995282c833092262396e67fa584