### PR TITLE
Allow undo while editing math fields

### DIFF
--- a/public/visor/index.html
+++ b/public/visor/index.html
@@ -1615,7 +1615,7 @@
           return;
         }
 
-        if (e.ctrlKey && e.key.toLowerCase() === 'z' && !e.shiftKey && !e.altKey) {
+        if (!isEditing && e.ctrlKey && e.key.toLowerCase() === 'z' && !e.shiftKey && !e.altKey) {
           e.preventDefault();
           undoLastStroke();
           return;


### PR DESCRIPTION
## Summary
- Respect edit mode when handling Ctrl+Z so users can undo text or formulas without affecting drawings

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: requires interactive ESLint config)


------
https://chatgpt.com/codex/tasks/task_e_68c2cab21218833095d24d2c93bd0e4e