### PR TITLE
feat: editable text annotations and stroke width control

### DIFF
--- a/public/visor/index.html
+++ b/public/visor/index.html
@@ -190,6 +190,35 @@
     }
     #draw-indicator.active { display: block; }
     .draw-canvas { position: absolute; top: 0; left: 0; z-index: 800; }
+    .text-annotation {
+      position: absolute;
+      min-width: 40px;
+      min-height: 24px;
+      padding: 4px 6px;
+      border: 1px dashed transparent;
+      border-radius: 4px;
+      background: transparent;
+      color: inherit;
+      font-size: 16px;
+      line-height: 1.2;
+      pointer-events: auto;
+      user-select: text;
+      touch-action: none;
+      z-index: 850;
+      cursor: grab;
+      white-space: pre-wrap;
+      word-break: break-word;
+      outline: none;
+      transition: border-color 0.2s ease;
+    }
+    .text-annotation.editing {
+      border-color: currentColor;
+      cursor: text;
+      caret-color: currentColor;
+    }
+    .text-annotation.moving {
+      cursor: grabbing;
+    }
 
     #draw-toolbar {
       position: fixed;
@@ -229,6 +258,20 @@
       margin-bottom: 4px;
     }
     #draw-toolbar input[type="range"] { flex: 1; }
+    #draw-toolbar input[type="number"] {
+      width: 64px;
+      background: rgba(255,255,255,0.1);
+      border: 1px solid rgba(255,255,255,0.3);
+      color: inherit;
+      padding: 2px 4px;
+      border-radius: 4px;
+    }
+    body.light-mode #draw-toolbar input[type="number"] {
+      background: rgba(0,0,0,0.05);
+      border-color: rgba(0,0,0,0.2);
+      color: #202124;
+    }
+    #draw-toolbar label span { flex: 1; }
 
     #focus-overlay {
       position: fixed;
@@ -617,6 +660,7 @@
             scheduleRender(pageNum);
           }
         }
+        repositionTextAnnotations();
         currentPage = cur;
         clearTimeout(redrawTimer);
         redrawTimer = setTimeout(loadDrawingsFromStorage, redrawDelay);
@@ -829,6 +873,283 @@
       let eraseMode = false;
 
       const BRUSH_SETTINGS_KEY = 'draw-settings';
+      const TEXT_ANNOTATION_PREFIX = 'text-annotation';
+
+      function getTextAnnotationKey(pageNum) {
+        if (!currentPdfKey) return null;
+        return `${TEXT_ANNOTATION_PREFIX}-${currentPdfKey}-page${pageNum}`;
+      }
+
+      function repositionTextAnnotations() {
+        document.querySelectorAll('.text-annotation').forEach(annotation => {
+          const wrapper = annotation.closest('.page-wrapper');
+          if (!wrapper) return;
+          const xp = parseFloat(annotation.dataset.xp || '0');
+          const yp = parseFloat(annotation.dataset.yp || '0');
+          const left = xp * wrapper.offsetWidth;
+          const top = yp * wrapper.offsetHeight;
+          annotation.style.left = left + 'px';
+          annotation.style.top = top + 'px';
+        });
+      }
+
+      function spawnTextAnnotation(canvas, event) {
+        const pageNum = parseInt(canvas.dataset.page || '0', 10);
+        if (!pageNum) return;
+        const xp = canvas.width ? event.offsetX / canvas.width : 0;
+        const yp = canvas.height ? event.offsetY / canvas.height : 0;
+        createTextAnnotationElement(pageNum, {
+          xp,
+          yp,
+          color: brushColor,
+          fontSize: Math.max(4, brushWidth * 4),
+          opacity: brushOpacity,
+          html: ''
+        }, { editing: true });
+        writeMode = false;
+      }
+
+      function loadTextAnnotationsFromStorage() {
+        if (!currentPdfKey) return;
+        container.querySelectorAll('.text-annotation').forEach(node => node.remove());
+        document.querySelectorAll('.page-wrapper').forEach(wrapper => {
+          const pageNum = parseInt(wrapper.dataset.pageNum, 10);
+          if (!pageNum) return;
+          const key = getTextAnnotationKey(pageNum);
+          if (!key) return;
+          let entries = [];
+          try {
+            const raw = localStorage.getItem(key);
+            if (raw) entries = JSON.parse(raw) || [];
+          } catch {
+            entries = [];
+          }
+          if (!Array.isArray(entries)) entries = [];
+          entries.forEach(entry => {
+            createTextAnnotationElement(pageNum, entry);
+          });
+        });
+        repositionTextAnnotations();
+      }
+
+      function createTextAnnotationElement(pageNum, data, options = {}) {
+        const wrapper = container.querySelector(`.page-wrapper[data-page-num="${pageNum}"]`);
+        if (!wrapper) return null;
+        const canvas = wrapper.querySelector('.draw-canvas');
+        if (!canvas) return null;
+        const annotation = document.createElement('div');
+        annotation.className = 'text-annotation';
+        const id = data.id || `${Date.now()}_${Math.random().toString(36).slice(2)}`;
+        annotation.dataset.id = id;
+        annotation.dataset.page = String(pageNum);
+        const rawXp = typeof data.xp === 'number' ? data.xp : parseFloat(data.xp || '0');
+        const rawYp = typeof data.yp === 'number' ? data.yp : parseFloat(data.yp || '0');
+        const clampedXp = Math.min(1, Math.max(0, isNaN(rawXp) ? 0 : rawXp));
+        const clampedYp = Math.min(1, Math.max(0, isNaN(rawYp) ? 0 : rawYp));
+        annotation.dataset.xp = String(clampedXp);
+        annotation.dataset.yp = String(clampedYp);
+        const baseFontSize = data.fontSize != null ? Number(data.fontSize) : brushWidth * 4;
+        const fontSize = Number.isFinite(baseFontSize) && baseFontSize > 0 ? baseFontSize : 12;
+        const color = typeof data.color === 'string' ? data.color : brushColor;
+        const rawOpacity = data.opacity != null ? Number(data.opacity) : brushOpacity;
+        const opacity = Number.isFinite(rawOpacity) ? Math.min(1, Math.max(0, rawOpacity)) : brushOpacity;
+        annotation.dataset.fontSize = String(fontSize);
+        annotation.dataset.color = color;
+        annotation.dataset.opacity = String(opacity);
+        annotation.style.fontSize = fontSize + 'px';
+        annotation.style.color = color;
+        annotation.style.opacity = String(opacity);
+        annotation.style.left = clampedXp * canvas.width + 'px';
+        annotation.style.top = clampedYp * canvas.height + 'px';
+        annotation.innerHTML = typeof data.html === 'string' ? data.html : '';
+        annotation.setAttribute('role', 'textbox');
+        annotation.setAttribute('aria-multiline', 'true');
+        wrapper.appendChild(annotation);
+        attachTextAnnotationEvents(annotation);
+        if (options.editing) {
+          requestAnimationFrame(() => startTextAnnotationEditing(annotation, true));
+        }
+        return annotation;
+      }
+
+      function attachTextAnnotationEvents(annotation) {
+        annotation.addEventListener('dblclick', (ev) => {
+          ev.preventDefault();
+          ev.stopPropagation();
+          startTextAnnotationEditing(annotation, true);
+        });
+        annotation.addEventListener('pointerdown', (ev) => {
+          if (annotation.contentEditable === 'true') return;
+          if (ev.button !== 0) return;
+          if (writeMode) return;
+          if (ev.detail > 1) return;
+          ev.preventDefault();
+          ev.stopPropagation();
+          startAnnotationDrag(annotation, ev);
+        });
+      }
+
+      function startAnnotationDrag(annotation, event) {
+        const wrapper = annotation.closest('.page-wrapper');
+        if (!wrapper) return;
+        annotation.classList.add('moving');
+        const pointerId = event.pointerId;
+        const startLeft = parseFloat(annotation.style.left || '0');
+        const startTop = parseFloat(annotation.style.top || '0');
+        const startX = event.clientX;
+        const startY = event.clientY;
+
+        const move = (ev) => {
+          if (ev.pointerId !== pointerId) return;
+          const dx = ev.clientX - startX;
+          const dy = ev.clientY - startY;
+          setAnnotationPosition(annotation, wrapper, startLeft + dx, startTop + dy);
+        };
+
+        const end = (ev) => {
+          if (ev.pointerId !== pointerId) return;
+          annotation.removeEventListener('pointermove', move);
+          annotation.removeEventListener('pointerup', end);
+          annotation.removeEventListener('pointercancel', end);
+          annotation.classList.remove('moving');
+          try { annotation.releasePointerCapture(pointerId); } catch {}
+          const pageNum = parseInt(annotation.dataset.page || '0', 10);
+          updateAnnotationStoredPosition(annotation);
+          if (pageNum) saveTextAnnotationsForPage(pageNum);
+        };
+
+        annotation.addEventListener('pointermove', move);
+        annotation.addEventListener('pointerup', end);
+        annotation.addEventListener('pointercancel', end);
+        try { annotation.setPointerCapture(pointerId); } catch {}
+      }
+
+      function setAnnotationPosition(annotation, wrapper, left, top) {
+        const maxLeft = Math.max(0, wrapper.offsetWidth - annotation.offsetWidth);
+        const maxTop = Math.max(0, wrapper.offsetHeight - annotation.offsetHeight);
+        const clampedLeft = Math.min(Math.max(left, 0), maxLeft);
+        const clampedTop = Math.min(Math.max(top, 0), maxTop);
+        annotation.style.left = clampedLeft + 'px';
+        annotation.style.top = clampedTop + 'px';
+        return { left: clampedLeft, top: clampedTop };
+      }
+
+      function updateAnnotationStoredPosition(annotation) {
+        const wrapper = annotation.closest('.page-wrapper');
+        if (!wrapper) return { xp: 0, yp: 0 };
+        const left = parseFloat(annotation.style.left || '0');
+        const top = parseFloat(annotation.style.top || '0');
+        const { left: clampedLeft, top: clampedTop } = setAnnotationPosition(annotation, wrapper, left, top);
+        const width = wrapper.offsetWidth || 1;
+        const height = wrapper.offsetHeight || 1;
+        const xp = clampedLeft / width;
+        const yp = clampedTop / height;
+        annotation.dataset.xp = String(xp);
+        annotation.dataset.yp = String(yp);
+        return { xp, yp };
+      }
+
+      function startTextAnnotationEditing(annotation, placeCaret = true) {
+        if (annotation.contentEditable === 'true') return;
+        annotation.classList.add('editing');
+        annotation.contentEditable = 'true';
+        requestAnimationFrame(() => {
+          annotation.focus();
+          if (placeCaret) {
+            const selection = window.getSelection();
+            if (selection) {
+              const range = document.createRange();
+              range.selectNodeContents(annotation);
+              range.collapse(false);
+              selection.removeAllRanges();
+              selection.addRange(range);
+            }
+          }
+        });
+        const keyHandler = (ev) => {
+          if (ev.key === 'Escape') {
+            ev.preventDefault();
+            annotation.blur();
+          } else if (ev.key === 'Enter' && ev.ctrlKey) {
+            ev.preventDefault();
+            annotation.blur();
+          }
+        };
+        const blurHandler = () => {
+          annotation.removeEventListener('keydown', keyHandler);
+          annotation.removeEventListener('blur', blurHandler);
+          finishTextAnnotationEditing(annotation);
+        };
+        annotation.addEventListener('keydown', keyHandler);
+        annotation.addEventListener('blur', blurHandler);
+      }
+
+      function finishTextAnnotationEditing(annotation) {
+        annotation.contentEditable = 'false';
+        annotation.classList.remove('editing');
+        const pageNum = parseInt(annotation.dataset.page || '0', 10);
+        if (annotationIsEmpty(annotation)) {
+          annotation.remove();
+          if (pageNum) saveTextAnnotationsForPage(pageNum);
+          return;
+        }
+        updateAnnotationStoredPosition(annotation);
+        if (pageNum) saveTextAnnotationsForPage(pageNum);
+      }
+
+      function annotationIsEmpty(annotation) {
+        return annotation.textContent.replace(/\u00a0/g, '').trim().length === 0;
+      }
+
+      function saveTextAnnotationsForPage(pageNum) {
+        const key = getTextAnnotationKey(pageNum);
+        if (!key) return;
+        const wrapper = container.querySelector(`.page-wrapper[data-page-num="${pageNum}"]`);
+        if (!wrapper) return;
+        const annotations = Array.from(wrapper.querySelectorAll('.text-annotation'));
+        if (!annotations.length) {
+          try { localStorage.removeItem(key); } catch {}
+          return;
+        }
+        const data = [];
+        for (const annotation of annotations) {
+          if (annotationIsEmpty(annotation)) continue;
+          const { xp, yp } = updateAnnotationStoredPosition(annotation);
+          const fontSize = parseFloat(annotation.dataset.fontSize || '12');
+          const opacity = parseFloat(annotation.dataset.opacity || '1');
+          data.push({
+            id: annotation.dataset.id,
+            xp,
+            yp,
+            color: annotation.dataset.color || brushColor,
+            fontSize: Number.isFinite(fontSize) && fontSize > 0 ? fontSize : 12,
+            opacity: Number.isFinite(opacity) ? Math.min(1, Math.max(0, opacity)) : 1,
+            html: annotation.innerHTML
+          });
+        }
+        if (!data.length) {
+          try { localStorage.removeItem(key); } catch {}
+          return;
+        }
+        try {
+          localStorage.setItem(key, JSON.stringify(data));
+        } catch (err) {
+          console.error('No se pudieron guardar las anotaciones de texto', err);
+        }
+      }
+
+      function clearTextAnnotations() {
+        if (!currentPdfKey) return;
+        document.querySelectorAll('.page-wrapper').forEach(wrapper => {
+          const pageNum = parseInt(wrapper.dataset.pageNum, 10);
+          if (!pageNum) return;
+          const key = getTextAnnotationKey(pageNum);
+          if (key) {
+            try { localStorage.removeItem(key); } catch {}
+          }
+          wrapper.querySelectorAll('.text-annotation').forEach(node => node.remove());
+        });
+      }
 
       function saveBrushSettings() {
         try {
@@ -854,6 +1175,10 @@
           if (data.shadowOffset) shadowOffset = data.shadowOffset;
           if (typeof data.brushOpacity === 'number') brushOpacity = data.brushOpacity;
           if (typeof data.redrawDelay === 'number') redrawDelay = data.redrawDelay;
+          brushWidth = Math.min(100, Math.max(1, Number(brushWidth) || 1));
+          shadowWidth = Math.min(50, Math.max(0, Number(shadowWidth) || 0));
+          shadowOffset = Math.min(50, Math.max(0, Number(shadowOffset) || 0));
+          brushOpacity = Math.min(1, Math.max(0, Number(brushOpacity) || 1));
         } catch {}
       }
 
@@ -867,7 +1192,7 @@
           <label>Carrera<input type="color" id="tool-stroke-color" value="#000000"></label>
           <label>Sombra<input type="color" id="tool-shadow-color" value="#000000"></label>
         </div>
-        <label>Ancho del cepillo <input type="range" id="tool-brush-width" min="1" max="100" value="2"></label>
+        <label class="range-field"><span>Ancho del cepillo</span><input type="range" id="tool-brush-width" min="1" max="100" value="2"><input type="number" id="tool-brush-width-number" min="1" max="100" value="2"></label>
         <label>Anchura del trazo <input type="range" id="tool-stroke-width" min="1" max="100" value="1"></label>
         <label>Ancho de sombra <input type="range" id="tool-shadow-width" min="0" max="50" value="0"></label>
         <label>Desplazamiento de <input type="range" id="tool-shadow-offset" min="0" max="50" value="0"></label>
@@ -881,6 +1206,7 @@
 
       const lineColorInput = drawToolbar.querySelector('#tool-line-color');
       const brushWidthInput = drawToolbar.querySelector('#tool-brush-width');
+      const brushWidthNumberInput = drawToolbar.querySelector('#tool-brush-width-number');
       const shadowColorInput = drawToolbar.querySelector('#tool-shadow-color');
       const shadowWidthInput = drawToolbar.querySelector('#tool-shadow-width');
       const shadowOffsetInput = drawToolbar.querySelector('#tool-shadow-offset');
@@ -890,7 +1216,29 @@
       const clearAllBtn = drawToolbar.querySelector('#tool-clear-all');
 
       lineColorInput.addEventListener('input', e => { brushColor = e.target.value; saveBrushSettings(); });
-      brushWidthInput.addEventListener('input', e => { brushWidth = parseInt(e.target.value, 10); saveBrushSettings(); });
+      brushWidthInput.addEventListener('input', e => {
+        const value = parseInt(e.target.value, 10);
+        if (!isNaN(value)) {
+          brushWidth = Math.min(100, Math.max(1, value));
+          if (brushWidthNumberInput) brushWidthNumberInput.value = String(brushWidth);
+          saveBrushSettings();
+        }
+      });
+      if (brushWidthNumberInput) {
+        brushWidthNumberInput.addEventListener('input', (e) => {
+          const value = parseInt(e.target.value, 10);
+          if (isNaN(value)) return;
+          brushWidth = Math.min(100, Math.max(1, value));
+          brushWidthInput.value = String(brushWidth);
+          brushWidthNumberInput.value = String(brushWidth);
+          saveBrushSettings();
+        });
+        brushWidthNumberInput.addEventListener('blur', () => {
+          if (!brushWidthNumberInput.value) {
+            brushWidthNumberInput.value = String(brushWidth);
+          }
+        });
+      }
       shadowColorInput.addEventListener('input', e => { shadowColor = e.target.value; saveBrushSettings(); });
       shadowWidthInput.addEventListener('input', e => { shadowWidth = parseInt(e.target.value, 10); saveBrushSettings(); });
       shadowOffsetInput.addEventListener('input', e => { shadowOffset = parseInt(e.target.value, 10); saveBrushSettings(); });
@@ -905,6 +1253,7 @@
       function applyBrushSettings() {
         lineColorInput.value = brushColor;
         brushWidthInput.value = brushWidth;
+        if (brushWidthNumberInput) brushWidthNumberInput.value = brushWidth;
         shadowColorInput.value = shadowColor;
         shadowWidthInput.value = shadowWidth;
         shadowOffsetInput.value = shadowOffset;
@@ -1317,6 +1666,7 @@
           observer.observe(wrapper);
         }
         loadDrawingsFromStorage();
+        loadTextAnnotationsFromStorage();
       }
 
       function clearContainer() {
@@ -2746,26 +3096,16 @@
           canvas._history = [];
           localStorage.removeItem(`drawing-${currentPdfKey}-page${canvas.dataset.page}`);
         });
+        clearTextAnnotations();
       }
 
       function startDraw(e) {
         if (!drawMode) return;
         const canvas = e.target;
         if (writeMode) {
-          const ctx = canvas.getContext('2d');
-          ctx.fillStyle = brushColor;
-          ctx.globalAlpha = brushOpacity;
-          ctx.shadowColor = shadowColor;
-          ctx.shadowBlur = shadowWidth;
-          ctx.shadowOffsetX = shadowOffset;
-          ctx.shadowOffsetY = shadowOffset;
-          ctx.font = `${brushWidth * 4}px sans-serif`;
-          const text = prompt('Texto:');
-          if (text) {
-            ctx.fillText(text, e.offsetX, e.offsetY);
-            saveDrawing(canvas);
-          }
-          writeMode = false;
+          e.preventDefault();
+          e.stopPropagation();
+          spawnTextAnnotation(canvas, e);
           return;
         }
         isDrawing = true;


### PR DESCRIPTION
## Summary
- add transparent inline text annotations with keyboard-activated editor, dragging support, and persistence per page
- reload annotations when PDFs are built or zoomed to keep text positioned correctly
- expose a numeric input alongside the brush width slider to control stroke size precisely

## Testing
- `pnpm lint` *(fails: prompts for initial ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68c85ca87e3883308e31871a146d7cef