### PR TITLE
Improve subject view and Moodle sync flow

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,6 +5,48 @@ import { useTheme } from "next-themes"
 
 const days = ["Lunes", "Martes", "Miércoles", "Jueves", "Viernes"]
 
+const normalizeSegment = (value: string) =>
+  value
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+
+const isTheorySegment = (segment: string) => {
+  const normalized = normalizeSegment(segment)
+  return normalized === "teoria" || normalized === "theory"
+}
+
+const isPracticeSegment = (segment: string) => {
+  const normalized = normalizeSegment(segment)
+  return normalized === "practica" || normalized === "practice"
+}
+
+const getLastSegment = (path: string) => {
+  const parts = path.split("/").filter(Boolean)
+  return parts.length ? parts[parts.length - 1] : ""
+}
+
+const extractSubjectPath = (path: string) => {
+  const segments = path.split("/").filter(Boolean)
+  if (!segments.length) return ""
+  if (segments.length === 1) return segments[0]
+  let endIndex = segments.length
+  for (let i = segments.length - 1; i >= 0; i--) {
+    if (isTheorySegment(segments[i]) || isPracticeSegment(segments[i])) {
+      endIndex = i
+      break
+    }
+  }
+  if (endIndex <= 0) return segments.join("/")
+  return segments.slice(0, endIndex).join("/") || segments.join("/")
+}
+
+const extractSubjectName = (path: string) => {
+  const subjectPath = extractSubjectPath(path)
+  const parts = subjectPath.split("/").filter(Boolean)
+  return parts.length ? parts[parts.length - 1] : ""
+}
+
 type PdfFile = {
   file: File
   path: string
@@ -14,6 +56,7 @@ type PdfFile = {
   isPdf: boolean
   url?: string
   mediaType?: 'pdf' | 'video' | 'link'
+  containerPath?: string
 }
 
 type DirectoryEntry = {
@@ -184,6 +227,21 @@ export default function Home() {
     setToast({ type, text })
     toastTimerRef.current = window.setTimeout(() => setToast(null), 3000)
   }, [])
+  const findCourseIdForSubject = useCallback(
+    (subject: string | null) => {
+      if (!subject) return null
+      const normalizedTarget = normalizeSegment(subject)
+      for (const config of moodleFolders) {
+        const configSubject = extractSubjectName(config.path || '')
+        if (!configSubject) continue
+        if (normalizeSegment(configSubject) === normalizedTarget) {
+          return config.courseId
+        }
+      }
+      return null
+    },
+    [moodleFolders],
+  )
   // const autoPausedRef = useRef(false)
   const [restored, setRestored] = useState(false)
   // Avoid hydration mismatch: render only after mounted
@@ -542,32 +600,45 @@ export default function Home() {
         return
       }
       const pathTarget = viewWeek ?? ''
+      const existing = moodleFolders.find((item) => item.path === pathTarget)
       const generatedId =
-        typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+        existing?.id ||
+        (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
           ? crypto.randomUUID()
-          : `${Date.now()}-${Math.random().toString(16).slice(2)}`
+          : `${Date.now()}-${Math.random().toString(16).slice(2)}`)
       const configToSync: MoodleFolderConfig = {
         id: generatedId,
         courseId,
         folderId,
         path: pathTarget,
-        name: newFolderName.trim() || undefined,
+        name:
+          newFolderName.trim() ||
+          existing?.name ||
+          (extractSubjectName(pathTarget) || undefined),
       }
       const result = await handleSyncMoodleFolder(configToSync)
       if (result.ok) {
         const timestamp = new Date().toISOString()
-        setMoodleFolders((prev) => [...prev, { ...configToSync, lastSynced: timestamp }])
+        setMoodleFolders((prev) => {
+          const filtered = prev.filter((item) => item.path !== pathTarget)
+          return [...filtered, { ...configToSync, lastSynced: timestamp }]
+        })
         showToastMessage('success', `Descargados ${result.count} archivos`)
         setMoodleError(null)
         setShowAddFolderForm(false)
-        setNewCourseId('')
-        setNewFolderId('')
-        setNewFolderName('')
       } else {
         showToastMessage('error', result.error)
       }
     },
-    [handleSyncMoodleFolder, newCourseId, newFolderId, newFolderName, showToastMessage, viewWeek],
+    [
+      handleSyncMoodleFolder,
+      moodleFolders,
+      newCourseId,
+      newFolderId,
+      newFolderName,
+      showToastMessage,
+      viewWeek,
+    ],
   )
 
   const selectDirectory = async () => {
@@ -634,8 +705,6 @@ export default function Home() {
   }, [darkModeStart, mounted])
 
   useEffect(() => {
-    const storedToken = localStorage.getItem('moodleToken')
-    if (storedToken && !moodleToken) setMoodleToken(storedToken)
     const storedFolders = localStorage.getItem('moodleFolders')
     if (storedFolders) {
       try {
@@ -644,6 +713,29 @@ export default function Home() {
       } catch {}
     }
   }, [])
+
+  useEffect(() => {
+    if (!showMoodleModal) {
+      setShowAddFolderForm(false)
+      setMoodleError(null)
+      return
+    }
+    const pathTarget = viewWeek ?? ''
+    const existing = moodleFolders.find((cfg) => cfg.path === pathTarget)
+    if (existing) {
+      setNewCourseId(String(existing.courseId ?? ''))
+      setNewFolderId(String(existing.folderId ?? ''))
+      setNewFolderName(existing.name ?? extractSubjectName(pathTarget) ?? '')
+    } else {
+      const subjectName = extractSubjectName(pathTarget)
+      const sharedCourseId = findCourseIdForSubject(subjectName)
+      setNewCourseId(sharedCourseId ? String(sharedCourseId) : '')
+      setNewFolderId('')
+      setNewFolderName(subjectName || '')
+    }
+    setShowAddFolderForm(true)
+    setMoodleError(null)
+  }, [showMoodleModal, viewWeek, moodleFolders, findCourseIdForSubject])
 
   useEffect(() => {
     ;(async () => {
@@ -721,11 +813,6 @@ export default function Home() {
 
   useEffect(() => {
     if (!mounted) return
-    localStorage.setItem('moodleToken', moodleToken)
-  }, [moodleToken, mounted])
-
-  useEffect(() => {
-    if (!mounted) return
     localStorage.setItem('moodleFolders', JSON.stringify(moodleFolders))
   }, [moodleFolders, mounted])
 
@@ -775,14 +862,30 @@ export default function Home() {
       const isVideo = /\.(mp4|webm|ogg|mov|mkv)$/.test(nameLower)
       if (!isPdf && !isVideo) continue
       const mediaType = isPdf ? 'pdf' : 'video'
+      const containerPath = dirPath
+      const subjectPath = extractSubjectPath(dirPath)
+      const subjectName = extractSubjectName(dirPath)
+      let tableType: "theory" | "practice" = 'theory'
+      const dirSegments = dirPath.split('/').filter(Boolean)
+      for (let i = dirSegments.length - 1; i >= 0; i--) {
+        if (isPracticeSegment(dirSegments[i])) {
+          tableType = 'practice'
+          break
+        }
+        if (isTheorySegment(dirSegments[i])) {
+          tableType = 'theory'
+          break
+        }
+      }
       const item: PdfFile = {
         file,
         path: parts.join("/"),
-        week: dirPath,
-        subject: "",
-        tableType: "theory",
+        week: subjectPath || dirPath,
+        subject: subjectName,
+        tableType,
         isPdf,
         mediaType,
+        containerPath,
       }
       entry.files.push(item)
     }
@@ -825,6 +928,17 @@ export default function Home() {
       setViewWeek(null)
     }
   }, [viewWeek, directoryTree])
+
+  useEffect(() => {
+    if (!viewWeek) return
+    const lastSegment = getLastSegment(viewWeek)
+    if (isTheorySegment(lastSegment) || isPracticeSegment(lastSegment)) {
+      const parent = viewWeek.split('/').filter(Boolean).slice(0, -1).join('/')
+      if (parent !== viewWeek) {
+        setViewWeek(parent || null)
+      }
+    }
+  }, [viewWeek, setViewWeek])
 
   // restore last opened file when queue is ready
   useEffect(() => {
@@ -1118,22 +1232,90 @@ export default function Home() {
   const selectedFiles = currentDirEntry.files
   const parentDirectory = currentDirEntry.parent
 
+  const collectFiles = (path: string): PdfFile[] => {
+    const entry = directoryTree[path]
+    if (!entry) return []
+    const nested = entry.subdirs.flatMap((sub) => collectFiles(sub))
+    return [...entry.files, ...nested]
+  }
+
+  const theoryChildPaths = childDirectories.filter((dir) =>
+    isTheorySegment(getLastSegment(dir)),
+  )
+  const practiceChildPaths = childDirectories.filter((dir) =>
+    isPracticeSegment(getLastSegment(dir)),
+  )
+  const aggregatedChildSet = new Set([...theoryChildPaths, ...practiceChildPaths])
+  const otherChildDirectories = childDirectories.filter(
+    (dir) => !aggregatedChildSet.has(dir),
+  )
+
+  const directTheoryFiles = selectedFiles.filter(
+    (file) => file.tableType === 'theory',
+  )
+  const directPracticeFiles = selectedFiles.filter(
+    (file) => file.tableType === 'practice',
+  )
+
+  const collectAndSort = (paths: string[], direct: PdfFile[]) => {
+    const combined = [...direct, ...paths.flatMap((path) => collectFiles(path))]
+    return combined.sort((a, b) =>
+      a.file.name.localeCompare(b.file.name, undefined, {
+        numeric: true,
+        sensitivity: 'base',
+      }),
+    )
+  }
+
+  const theoryFiles = collectAndSort(theoryChildPaths, directTheoryFiles)
+  const practiceFiles = collectAndSort(practiceChildPaths, directPracticeFiles)
+  const currentDepth = (viewWeek?.split('/').filter(Boolean).length ?? 0)
+  const showTheoryPractice =
+    currentDepth >= 2 &&
+    (theoryFiles.length > 0 || practiceFiles.length > 0 || aggregatedChildSet.size > 0)
+
+  const renderFileList = (files: PdfFile[]) => (
+    <ul className="space-y-1">
+      {files.map((p) => (
+        <li
+          key={p.path}
+          className={`flex items-center gap-2 ${
+            completed[p.path] ? 'line-through text-gray-400' : ''
+          }`}
+        >
+          <span
+            className="flex-1 truncate cursor-pointer"
+            title={p.file.name}
+            onClick={() => handleSelectFile(p)}
+          >
+            {p.file.name}
+            {p.mediaType === 'video' && (
+              <span className="ml-2 text-xs text-indigo-500 uppercase">Video</span>
+            )}
+          </span>
+        </li>
+      ))}
+    </ul>
+  )
+
   const formatDirLabel = (path: string) => {
     const segments = path.split("/").filter(Boolean)
     const name = segments.length ? segments[segments.length - 1] : path || "Inicio"
     const entry = directoryTree[path]
     if (!entry) return name
+    const extras: string[] = []
     if (entry.subdirs.length > 0) {
-      return `${name} {${entry.subdirs.length} materias}`
+      extras.push(
+        `${entry.subdirs.length} ${
+          entry.subdirs.length === 1 ? 'carpeta' : 'carpetas'
+        }`,
+      )
     }
-    const pdfFiles = entry.files.filter((file) => file.mediaType !== 'video')
-    const videoFiles = entry.files.filter((file) => file.mediaType === 'video')
-    const completedPdf = pdfFiles.filter((file) => completed[file.path]).length
-    const pdfLabel = `${completedPdf}/${pdfFiles.length || 0} pdf`
-    const videoLabel = videoFiles.length
-      ? ` · ${videoFiles.length} video${videoFiles.length === 1 ? '' : 's'}`
-      : ''
-    return `${name} {${pdfLabel}${videoLabel}}`
+    const videoCount = entry.files.filter((file) => file.mediaType === 'video').length
+    if (videoCount > 0) {
+      extras.push(`${videoCount} video${videoCount === 1 ? '' : 's'}`)
+    }
+    return extras.length ? `${name} · ${extras.join(' · ')}` : name
   }
 
   const formatBreadcrumb = (path: string | null) => {
@@ -1163,9 +1345,9 @@ export default function Home() {
             </div>
           )}
           <h2 className="text-xl">{formatBreadcrumb(viewWeek)}</h2>
-          {childDirectories.length > 0 && (
+          {otherChildDirectories.length > 0 && (
             <ul className="space-y-1">
-              {childDirectories.map((dir) => (
+              {otherChildDirectories.map((dir) => (
                 <li key={dir} className="font-bold">
                   <button onClick={() => setViewWeek(dir)}>
                     {formatDirLabel(dir)}
@@ -1174,37 +1356,40 @@ export default function Home() {
               ))}
             </ul>
           )}
-          {selectedFiles.length > 0 && (
+          {showTheoryPractice ? (
+            <div className="space-y-4">
+              <div>
+                <h3 className="text-sm font-semibold text-gray-500 uppercase">Teoría</h3>
+                {theoryFiles.length ? (
+                  renderFileList(theoryFiles)
+                ) : (
+                  <p className="text-xs text-gray-500">Sin archivos</p>
+                )}
+              </div>
+              <div>
+                <h3 className="text-sm font-semibold text-gray-500 uppercase">Práctica</h3>
+                {practiceFiles.length ? (
+                  renderFileList(practiceFiles)
+                ) : (
+                  <p className="text-xs text-gray-500">Sin archivos</p>
+                )}
+              </div>
+            </div>
+          ) : selectedFiles.length > 0 ? (
             <div className={childDirectories.length > 0 ? "space-y-1" : ""}>
               {childDirectories.length > 0 && (
                 <h3 className="text-sm font-semibold text-gray-500 uppercase">
                   Archivos
                 </h3>
               )}
-              <ul className="space-y-1">
-                {selectedFiles.map((p) => (
-                  <li
-                    key={p.path}
-                    className={`flex items-center gap-2 ${
-                      completed[p.path] ? "line-through text-gray-400" : ""
-                    }`}
-                  >
-                    <span
-                      className="flex-1 truncate cursor-pointer"
-                      title={p.file.name}
-                      onClick={() => handleSelectFile(p)}
-                    >
-                      {p.file.name}
-                      {p.mediaType === 'video' && (
-                        <span className="ml-2 text-xs text-indigo-500 uppercase">Video</span>
-                      )}
-                    </span>
-                  </li>
-                ))}
-              </ul>
+              {renderFileList(selectedFiles)}
             </div>
-          )}
-          {childDirectories.length === 0 && selectedFiles.length === 0 && (
+          ) : null}
+          {(showTheoryPractice
+            ? theoryFiles.length === 0 &&
+              practiceFiles.length === 0 &&
+              otherChildDirectories.length === 0
+            : childDirectories.length === 0 && selectedFiles.length === 0) && (
             <p className="text-sm text-gray-500">Carpeta vacía</p>
           )}
         </aside>


### PR DESCRIPTION
## Summary
- categorize directory entries to surface Teoría and Práctica files together when browsing a subject and simplify list labels
- derive subject metadata while building the file tree so queue entries keep subject/week context without showing hidden folders
- streamline the Moodle sync modal to reuse course IDs across weeks, keep per-folder settings, and avoid persisting tokens beyond the session

## Testing
- pnpm lint *(fails: command requires interactive configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68ddbb92a2688330878b249f9c37a659