### PR TITLE
Add subject scoped quick links and routes

### DIFF
--- a/app/[mode]/[subject]/page.tsx
+++ b/app/[mode]/[subject]/page.tsx
@@ -1,0 +1,1 @@
+export { default } from "../../page"


### PR DESCRIPTION
## Summary
- add default quick link slots for teoría/práctica de Álgebra, Cálculo y POO so the overlay siempre ofrece seis accesos
- navegar enlaces internos con el router de Next para reabrir el visor dentro de la misma app
- exponer la página del visor bajo la ruta dinámica /[mode]/[subject] para soportar accesos como /teoria/algebra

## Testing
- npm run lint *(falla: el comando solicita configurar ESLint de forma interactiva)*

------
https://chatgpt.com/codex/tasks/task_e_68e3237f5a2c8330b9fa97c83826f21d