### PR TITLE
Improve instant selection PDF quality

### DIFF
--- a/public/visor/index.html
+++ b/public/visor/index.html
@@ -3040,6 +3040,9 @@
         const resultDoc = await window.PDFLib.PDFDocument.create();
         const pxToPt = 72 / 96;
         const ratio = window.devicePixelRatio || 1;
+        const TARGET_LONG_SIDE = 1800;
+        const MIN_RENDER_SCALE = 2;
+        const MAX_RENDER_SCALE = 10;
 
         for (const selection of instantSelections) {
           const { pageNum, xp1, yp1, xp2, yp2 } = selection;
@@ -3048,24 +3051,42 @@
           if (widthFrac === 0 || heightFrac === 0) continue;
 
           const page = await pdfDoc.getPage(pageNum);
-          const scale = Math.max(2, ratio * 2);
-          const viewport = page.getViewport({ scale });
-          const x1 = Math.min(xp1, xp2) * viewport.width;
-          const y1 = Math.min(yp1, yp2) * viewport.height;
+          const baseViewport = page.getViewport({ scale: 1 });
+          const cssWidth = widthFrac * baseViewport.width;
+          const cssHeight = heightFrac * baseViewport.height;
+          const longestSide = Math.max(cssWidth, cssHeight);
+          const desiredScale = longestSide ? Math.max(1, TARGET_LONG_SIDE / longestSide) : 1;
+          const renderScale = Math.min(
+            MAX_RENDER_SCALE,
+            Math.max(MIN_RENDER_SCALE, desiredScale * ratio),
+          );
+          const viewport = page.getViewport({ scale: renderScale });
+          const minXp = Math.min(xp1, xp2);
+          const minYp = Math.min(yp1, yp2);
+          const x1 = minXp * viewport.width;
+          const y1 = minYp * viewport.height;
           const w = widthFrac * viewport.width;
           const h = heightFrac * viewport.height;
           const canvas = document.createElement('canvas');
           canvas.width = Math.max(1, Math.round(w));
           canvas.height = Math.max(1, Math.round(h));
-          const ctx = canvas.getContext('2d');
-          ctx.translate(-x1, -y1);
-          await page.render({ canvasContext: ctx, viewport }).promise;
+          const ctx = canvas.getContext('2d', { alpha: false });
+          if (!ctx) continue;
+          ctx.fillStyle = '#fff';
+          ctx.fillRect(0, 0, canvas.width, canvas.height);
+          ctx.imageSmoothingEnabled = true;
+          ctx.imageSmoothingQuality = 'high';
+          await page.render({
+            canvasContext: ctx,
+            viewport,
+            transform: [1, 0, 0, 1, -x1, -y1],
+          }).promise;
 
           const state = pageStates.get(pageNum);
           const drawCanvas = state?.wrapper?.querySelector('.draw-canvas');
           if (drawCanvas) {
-            const sx2 = Math.round(Math.min(xp1, xp2) * drawCanvas.width);
-            const sy2 = Math.round(Math.min(yp1, yp2) * drawCanvas.height);
+            const sx2 = Math.round(minXp * drawCanvas.width);
+            const sy2 = Math.round(minYp * drawCanvas.height);
             const sw2 = Math.max(1, Math.round(widthFrac * drawCanvas.width));
             const sh2 = Math.max(1, Math.round(heightFrac * drawCanvas.height));
             ctx.drawImage(drawCanvas, sx2, sy2, sw2, sh2, 0, 0, canvas.width, canvas.height);
@@ -3074,10 +3095,17 @@
           const dataUrl = canvas.toDataURL('image/png');
           const pngBytes = await (await fetch(dataUrl)).arrayBuffer();
           const embedded = await resultDoc.embedPng(pngBytes);
-          const pageWidth = canvas.width * pxToPt;
-          const pageHeight = canvas.height * pxToPt;
-          const newPage = resultDoc.addPage([pageWidth, pageHeight]);
-          newPage.drawImage(embedded, { x: 0, y: 0, width: pageWidth, height: pageHeight });
+          const pageWidth = cssWidth * pxToPt;
+          const pageHeight = cssHeight * pxToPt;
+          const safePageWidth = Math.max(pageWidth, pxToPt);
+          const safePageHeight = Math.max(pageHeight, pxToPt);
+          const newPage = resultDoc.addPage([safePageWidth, safePageHeight]);
+          newPage.drawImage(embedded, {
+            x: (safePageWidth - pageWidth) / 2,
+            y: (safePageHeight - pageHeight) / 2,
+            width: pageWidth,
+            height: pageHeight,
+          });
         }
 
         if (resultDoc.getPageCount() === 0) return 0;


### PR DESCRIPTION
## Summary
- increase the render scale for instant selection exports based on the selected area's size and device pixel ratio
- render cropped selections onto high-resolution canvases, include annotations, and center them on safely sized PDF pages

## Testing
- `npm run lint` *(fails: command prompts for ESLint configuration in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e63cbbde8c8330ac8f86002ac0de8a